### PR TITLE
fix(#3121826): add on-demand image style delivery for temporary:// staged files

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -42,6 +42,7 @@
         "gnomovision",
         "hookspec",
         "icanon",
+        "itok",
         "initialisation",
         "initialised",
         "jangregor",

--- a/filefield_paths.module
+++ b/filefield_paths.module
@@ -221,6 +221,12 @@ function filefield_paths_file_url_alter(string &$uri): void {// phpcs:ignore Dru
 
 // @phpstan-ignore-next-line
 #[LegacyHook]
+function filefield_paths_file_download(string $uri): array|null {// phpcs:ignore Drupal.Commenting.FunctionComment.Missing, Squiz.WhiteSpace.FunctionSpacing.Before
+  return \Drupal::service(FileUrlHooks::class)->fileDownload($uri);
+}
+
+// @phpstan-ignore-next-line
+#[LegacyHook]
 function filefield_paths_local_tasks_alter(array &$local_tasks): void {// phpcs:ignore Drupal.Commenting.FunctionComment.Missing, Squiz.WhiteSpace.FunctionSpacing.Before
   \Drupal::service(LocalTaskAlter::class)
     ->localTasksAlterImplementation($local_tasks);

--- a/filefield_paths.module
+++ b/filefield_paths.module
@@ -26,6 +26,7 @@ use Drupal\filefield_paths\Hook\FieldWidgetSingleElementForm;
 use Drupal\filefield_paths\Hook\File;
 use Drupal\filefield_paths\Hook\FileFieldPathsFieldSettingsLegacy;
 use Drupal\filefield_paths\Hook\FileFieldPathsProcessFileLegacy;
+use Drupal\filefield_paths\Hook\FileUrlHooks;
 use Drupal\filefield_paths\Hook\LocalTaskAlter;
 use Drupal\filefield_paths\Hook\Tokens;
 use Drupal\filefield_paths\MoveFileProcessorInterface;
@@ -210,6 +211,12 @@ function filefield_paths_entity_base_field_info(EntityTypeInterface $entity_type
 #[LegacyHook]
 function filefield_paths_file_presave(FileInterface $file): void {// phpcs:ignore Drupal.Commenting.FunctionComment.Missing, Squiz.WhiteSpace.FunctionSpacing.Before
   \Drupal::service(File::class)->filePresave($file);
+}
+
+// @phpstan-ignore-next-line
+#[LegacyHook]
+function filefield_paths_file_url_alter(string &$uri): void {// phpcs:ignore Drupal.Commenting.FunctionComment.Missing, Squiz.WhiteSpace.FunctionSpacing.Before
+  \Drupal::service(FileUrlHooks::class)->fileUrlAlter($uri);
 }
 
 // @phpstan-ignore-next-line

--- a/filefield_paths.routing.yml
+++ b/filefield_paths.routing.yml
@@ -5,3 +5,15 @@ filefield_paths.admin_settings:
     _title: 'File (Field) Paths settings'
   requirements:
     _permission: 'administer site configuration'
+
+filefield_paths.image_style_temporary:
+  path: '/system/files/styles/{image_style}/temporary'
+  defaults:
+    _controller: '\Drupal\image\Controller\ImageStyleDownloadController::deliver'
+    scheme: 'temporary'
+    required_derivative_scheme: 'temporary'
+  requirements:
+    _access: 'TRUE'
+    _ffp_temp_image_style: 'TRUE'
+  options:
+    no_cache: TRUE

--- a/filefield_paths.routing.yml
+++ b/filefield_paths.routing.yml
@@ -7,13 +7,12 @@ filefield_paths.admin_settings:
     _permission: 'administer site configuration'
 
 filefield_paths.image_style_temporary:
-  path: '/system/files/styles/{image_style}/temporary'
+  path: '/filefield_paths/image-style/{image_style}/temporary'
   defaults:
     _controller: '\Drupal\image\Controller\ImageStyleDownloadController::deliver'
     scheme: 'temporary'
     required_derivative_scheme: 'temporary'
   requirements:
-    _access: 'TRUE'
     _ffp_temp_image_style: 'TRUE'
   options:
     no_cache: TRUE

--- a/filefield_paths.services.yml
+++ b/filefield_paths.services.yml
@@ -20,6 +20,12 @@ services:
     class: Drupal\filefield_paths\PathProcessor
     autowire: true
 
+  filefield_paths.access_checker.image_style_temporary:
+    class: Drupal\filefield_paths\Access\ImageStyleTemporaryAccessCheck
+    arguments: ['@config.factory']
+    tags:
+      - { name: access_check, applies_to: _ffp_temp_image_style }
+
   # Legacy hook support
   Drupal\filefield_paths\Hook\EntityWithFileField:
     class: Drupal\filefield_paths\Hook\EntityWithFileField
@@ -44,4 +50,7 @@ services:
     autowire: true
   Drupal\filefield_paths\Hook\Tokens:
     class: Drupal\filefield_paths\Hook\Tokens
+    autowire: true
+  Drupal\filefield_paths\Hook\FileUrlHooks:
+    class: Drupal\filefield_paths\Hook\FileUrlHooks
     autowire: true

--- a/src/Access/ImageStyleTemporaryAccessCheck.php
+++ b/src/Access/ImageStyleTemporaryAccessCheck.php
@@ -36,14 +36,9 @@ final readonly class ImageStyleTemporaryAccessCheck implements AccessInterface {
       ->get('filefield_paths.settings')
       ->get('temp_location') ?? '';
 
-    $scheme = StreamWrapperManager::getScheme($temp_location);
     $subdir = StreamWrapperManager::getTarget($temp_location);
-
-    // Only enforce the prefix restriction when the configured temp location
-    // uses temporary://. Other schemes (private://, public://) are handled by
-    // their own access mechanisms and should not be blocked here.
-    if ($scheme !== 'temporary' || $subdir === '' || $subdir === FALSE) {
-      return AccessResult::neutral();
+    if (!is_string($subdir) || $subdir === '') {
+      return AccessResult::forbidden();
     }
 
     $allowed = str_starts_with($file, $subdir . '/');

--- a/src/Access/ImageStyleTemporaryAccessCheck.php
+++ b/src/Access/ImageStyleTemporaryAccessCheck.php
@@ -6,6 +6,7 @@ namespace Drupal\filefield_paths\Access;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
@@ -27,25 +28,35 @@ final readonly class ImageStyleTemporaryAccessCheck implements AccessInterface {
    * Checks access for the temporary image style delivery route.
    */
   public function access(Request $request): AccessResultInterface {
+    $cacheability = (new CacheableMetadata())
+      ->setCacheContexts(['url.query_args:file'])
+      ->setCacheTags(['config:filefield_paths.settings']);
+
     $file = (string) ($request->query->get('file') ?? '');
     if ($file === '') {
-      return AccessResult::forbidden();
+      return AccessResult::forbidden()->addCacheableDependency($cacheability);
     }
 
     $temp_location = $this->configFactory
       ->get('filefield_paths.settings')
       ->get('temp_location') ?? '';
 
-    $subdir = StreamWrapperManager::getTarget($temp_location);
-    if (!is_string($subdir) || $subdir === '') {
-      return AccessResult::forbidden();
+    if (StreamWrapperManager::getScheme($temp_location) !== 'temporary') {
+      return AccessResult::forbidden()->addCacheableDependency($cacheability);
     }
 
-    $allowed = str_starts_with($file, $subdir . '/');
+    $subdir = StreamWrapperManager::getTarget($temp_location);
+    if (!is_string($subdir) || $subdir === '') {
+      return AccessResult::forbidden()->addCacheableDependency($cacheability);
+    }
 
-    return ($allowed ? AccessResult::allowed() : AccessResult::forbidden())
-      ->addCacheContexts(['url.query_args:file'])
-      ->addCacheTags(['config:filefield_paths.settings']);
+    $normalized_file = ltrim(str_replace('\\', '/', $file), '/');
+    if (preg_match('~(^|/)\.\.(/|$)~', $normalized_file)) {
+      return AccessResult::forbidden()->addCacheableDependency($cacheability);
+    }
+
+    $allowed = str_starts_with($normalized_file, $subdir . '/');
+    return AccessResult::allowedIf($allowed)->addCacheableDependency($cacheability);
   }
 
 }

--- a/src/Access/ImageStyleTemporaryAccessCheck.php
+++ b/src/Access/ImageStyleTemporaryAccessCheck.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\filefield_paths\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\StreamWrapper\StreamWrapperManager;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Restricts the temporary image style route to the FFP staging subdirectory.
+ *
+ * Prevents the route from serving derivatives for arbitrary temporary:// files
+ * outside the configured File (Field) Paths temp location.
+ */
+final readonly class ImageStyleTemporaryAccessCheck implements AccessInterface {
+
+  public function __construct(
+    private ConfigFactoryInterface $configFactory,
+  ) {}
+
+  /**
+   * Checks access for the temporary image style delivery route.
+   */
+  public function access(Request $request): AccessResultInterface {
+    $file = (string) ($request->query->get('file') ?? '');
+    if ($file === '') {
+      return AccessResult::forbidden();
+    }
+
+    $temp_location = $this->configFactory
+      ->get('filefield_paths.settings')
+      ->get('temp_location') ?? '';
+
+    $scheme = StreamWrapperManager::getScheme($temp_location);
+    $subdir = StreamWrapperManager::getTarget($temp_location);
+
+    // Only enforce the prefix restriction when the configured temp location
+    // uses temporary://. Other schemes (private://, public://) are handled by
+    // their own access mechanisms and should not be blocked here.
+    if ($scheme !== 'temporary' || $subdir === '' || $subdir === FALSE) {
+      return AccessResult::neutral();
+    }
+
+    $allowed = str_starts_with($file, $subdir . '/');
+
+    return ($allowed ? AccessResult::allowed() : AccessResult::forbidden())
+      ->addCacheContexts(['url.query_args:file'])
+      ->addCacheTags(['config:filefield_paths.settings']);
+  }
+
+}

--- a/src/Hook/FileUrlHooks.php
+++ b/src/Hook/FileUrlHooks.php
@@ -4,20 +4,38 @@ declare(strict_types=1);
 
 namespace Drupal\filefield_paths\Hook;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\Core\Url;
 
 /**
  * File URL hook implementations.
  */
-final class FileUrlHooks {
+final readonly class FileUrlHooks {
+
+  public function __construct(
+    private ConfigFactoryInterface $configFactory,
+  ) {}
 
   /**
    * Implements hook_file_url_alter().
+   *
+   * Rewrites image style derivative URLs for files staged in temporary:// so
+   * that they route through a dedicated delivery controller instead of the
+   * core temporary stream wrapper (which cannot serve image derivatives).
    */
   // @phpstan-ignore-next-line
   #[Hook('file_url_alter')]
   public function fileUrlAlter(string &$uri): void {// phpcs:ignore Squiz.WhiteSpace.FunctionSpacing.Before
+    $temp_location = $this->configFactory
+      ->get('filefield_paths.settings')
+      ->get('temp_location') ?? '';
+
+    if (StreamWrapperManager::getScheme($temp_location) !== 'temporary') {
+      return;
+    }
+
     if (preg_match('#^temporary://styles/([^/]+)/temporary/(.+)$#', $uri, $m)) {
       $uri = Url::fromRoute(
         'filefield_paths.image_style_temporary',

--- a/src/Hook/FileUrlHooks.php
+++ b/src/Hook/FileUrlHooks.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\filefield_paths\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Url;
+
+/**
+ * File URL hook implementations.
+ */
+final class FileUrlHooks {
+
+  /**
+   * Implements hook_file_url_alter().
+   */
+  // @phpstan-ignore-next-line
+  #[Hook('file_url_alter')]
+  public function fileUrlAlter(string &$uri): void {// phpcs:ignore Squiz.WhiteSpace.FunctionSpacing.Before
+    if (preg_match('#^temporary://styles/([^/]+)/temporary/(.+)$#', $uri, $m)) {
+      $uri = Url::fromRoute(
+        'filefield_paths.image_style_temporary',
+        ['image_style' => $m[1]],
+        ['query' => ['file' => $m[2]], 'absolute' => TRUE],
+      )->toString();
+    }
+  }
+
+}

--- a/src/Hook/FileUrlHooks.php
+++ b/src/Hook/FileUrlHooks.php
@@ -36,7 +36,11 @@ final readonly class FileUrlHooks {
       return;
     }
 
-    if (preg_match('#^temporary://styles/([^/]+)/temporary/(.+)$#', $uri, $m)) {
+    $subdir = StreamWrapperManager::getTarget($temp_location);
+    if (is_string($subdir) && $subdir !== ''
+      && preg_match('#^temporary://styles/([^/]+)/temporary/(.+)$#', $uri, $m)
+      && str_starts_with($m[2], $subdir . '/')
+    ) {
       $uri = Url::fromRoute(
         'filefield_paths.image_style_temporary',
         ['image_style' => $m[1]],
@@ -88,8 +92,14 @@ final readonly class FileUrlHooks {
 
     $subdir = StreamWrapperManager::getTarget($temp_location);
     $target = StreamWrapperManager::getTarget($uri);
-    if (!is_string($subdir) || $subdir === ''
-      || !is_string($target)
+    if (!is_string($subdir) || !is_string($target)) {
+      return NULL;
+    }
+
+    $subdir = trim(str_replace('\\', '/', $subdir), '/');
+    $target = ltrim(str_replace('\\', '/', $target), '/');
+    if ($subdir === ''
+      || preg_match('~(^|/)\.\.(/|$)~', $target)
       || !str_starts_with($target, $subdir . '/')
     ) {
       return NULL;

--- a/src/Hook/FileUrlHooks.php
+++ b/src/Hook/FileUrlHooks.php
@@ -10,7 +10,7 @@ use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\Core\Url;
 
 /**
- * File URL hook implementations.
+ * File URL and download hook implementations.
  */
 final readonly class FileUrlHooks {
 
@@ -43,6 +43,59 @@ final readonly class FileUrlHooks {
         ['query' => ['file' => $m[2]], 'absolute' => TRUE],
       )->toString();
     }
+  }
+
+  /**
+   * Implements hook_file_download().
+   *
+   * Grants access to source files staged inside the configured FFP
+   * temporary:// subdirectory so that ImageStyleDownloadController can
+   * generate and serve derivatives.
+   *
+   * Drupal 11.4 removed the token-valid shortcut that previously treated
+   * temporary:// as a public scheme during image style delivery. The
+   * controller now always invokes hook_file_download() for non-public
+   * schemes, so without an explicit grant here, derivative requests for
+   * temporary:// staged files receive a 403.
+   *
+   * Security: the image style derivative token (itok) is validated by the
+   * controller before this hook runs, and the route access checker
+   * (ImageStyleTemporaryAccessCheck) already restricted the request to the
+   * FFP temp subdirectory. This hook only needs to confirm the source URI
+   * itself lives within that subdirectory.
+   *
+   * Only the Content-Disposition header is returned: the controller sets
+   * Content-Type and Content-Length from the generated derivative via array
+   * union, and returning those from the source would mask derivative MIME
+   * types for converting image styles.
+   *
+   * @return array<string, mixed>|null
+   *   A non-empty headers array to grant access, or NULL for no opinion.
+   */
+  #[Hook('file_download')]
+  public function fileDownload(string $uri): array|null {
+    if (StreamWrapperManager::getScheme($uri) !== 'temporary') {
+      return NULL;
+    }
+
+    $temp_location = $this->configFactory
+      ->get('filefield_paths.settings')
+      ->get('temp_location') ?? '';
+
+    if (StreamWrapperManager::getScheme($temp_location) !== 'temporary') {
+      return NULL;
+    }
+
+    $subdir = StreamWrapperManager::getTarget($temp_location);
+    $target = StreamWrapperManager::getTarget($uri);
+    if (!is_string($subdir) || $subdir === ''
+      || !is_string($target)
+      || !str_starts_with($target, $subdir . '/')
+    ) {
+      return NULL;
+    }
+
+    return ['Content-Disposition' => 'inline'];
   }
 
 }

--- a/tests/src/Functional/FileFieldPathsImageStyleTemporaryTest.php
+++ b/tests/src/Functional/FileFieldPathsImageStyleTemporaryTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\filefield_paths\Functional;
+
+use Drupal\Core\File\FileExists;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\image\Entity\ImageStyle;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests on-demand image style delivery for temporary:// staged files.
+ *
+ * @group filefield_paths
+ */
+class FileFieldPathsImageStyleTemporaryTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['filefield_paths', 'image'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Image style used across tests.
+   */
+  protected ImageStyle $style;
+
+  /**
+   * URI of the test image staged in temporary://.
+   */
+  protected string $imageUri;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Create a simple image style.
+    $this->style = ImageStyle::create(['name' => 'ffp_test', 'label' => 'FFP test']);
+    $this->style->save();
+
+    // Copy a core test image into the FFP temp location.
+    $temp_location = 'temporary://filefield_paths';
+    \Drupal::service('file_system')->prepareDirectory(
+      $temp_location,
+      FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS,
+    );
+    $source = \Drupal::root() . '/core/tests/fixtures/files/image-1.png';
+    $this->imageUri = \Drupal::service('file_system')
+      ->copy($source, $temp_location . '/image-1.png', FileExists::Replace);
+  }
+
+  /**
+   * Tests that image style derivatives are served for temporary:// files.
+   */
+  public function testDerivativeIsServed(): void {
+    $url = $this->style->buildUrl($this->imageUri);
+
+    $this->drupalGet($url);
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseHeaderContains('Content-Type', 'image/');
+  }
+
+  /**
+   * Tests that a missing or invalid itok returns 404.
+   */
+  public function testMissingTokenReturns404(): void {
+    $url = $this->style->buildUrl($this->imageUri);
+
+    // Strip the itok parameter.
+    $url_no_token = preg_replace('/[?&]itok=[^&]+/', '', $url);
+
+    $this->drupalGet($url_no_token);
+    $this->assertSession()->statusCodeEquals(404);
+  }
+
+  /**
+   * Tests that ?file= outside the FFP subdirectory returns 403.
+   */
+  public function testFileOutsideSubdirReturns403(): void {
+    $url = $this->style->buildUrl($this->imageUri);
+
+    // Replace the FFP subdirectory prefix with a different path.
+    $url_outside = preg_replace('#(\?|&)file=filefield_paths/#', '$1file=other_module/', $url);
+
+    $this->drupalGet($url_outside);
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+  /**
+   * Tests private:// temp location leaves private delivery intact.
+   *
+   * The alter hook only matches temporary:// derivative URIs, so switching
+   * the temp location to private:// must not trigger the FFP temporary route.
+   */
+  public function testPrivateTempLocationUnaffected(): void {
+    \Drupal::configFactory()
+      ->getEditable('filefield_paths.settings')
+      ->set('temp_location', 'private://filefield_paths')
+      ->save();
+
+    $private_uri = 'private://filefield_paths/image-1.png';
+    $derivative_uri = $this->style->buildUri($private_uri);
+    $this->assertStringStartsWith('private://', $derivative_uri);
+  }
+
+}

--- a/tests/src/Functional/FileFieldPathsImageStyleTemporaryTest.php
+++ b/tests/src/Functional/FileFieldPathsImageStyleTemporaryTest.php
@@ -119,6 +119,16 @@ class FileFieldPathsImageStyleTemporaryTest extends BrowserTestBase {
   }
 
   /**
+   * Tests that a path traversal attempt in ?file= returns 403.
+   */
+  public function testPathTraversalReturns403(): void {
+    $url = $this->style->buildUrl($this->imageUri);
+    $url_traversal = preg_replace('#(\?|&)file=filefield_paths/#', '$1file=filefield_paths/../', $url);
+    $this->drupalGet($url_traversal);
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+  /**
    * Tests that non-temporary temp_location does not trigger URL rewriting.
    *
    * When temp_location uses private://, the alter hook must not intercept

--- a/tests/src/Functional/FileFieldPathsImageStyleTemporaryTest.php
+++ b/tests/src/Functional/FileFieldPathsImageStyleTemporaryTest.php
@@ -42,6 +42,12 @@ class FileFieldPathsImageStyleTemporaryTest extends BrowserTestBase {
   protected function setUp(): void {
     parent::setUp();
 
+    // Use temporary:// as the FFP temp location so the URL alter hook fires.
+    \Drupal::configFactory()
+      ->getEditable('filefield_paths.settings')
+      ->set('temp_location', 'temporary://filefield_paths')
+      ->save();
+
     // Create a simple image style.
     $this->style = ImageStyle::create(['name' => 'ffp_test', 'label' => 'FFP test']);
     $this->style->save();
@@ -55,6 +61,16 @@ class FileFieldPathsImageStyleTemporaryTest extends BrowserTestBase {
     $source = \Drupal::root() . '/core/tests/fixtures/files/image-1.png';
     $this->imageUri = \Drupal::service('file_system')
       ->copy($source, $temp_location . '/image-1.png', FileExists::Replace);
+  }
+
+  /**
+   * Tests that derivative URLs are rewritten to the FFP route.
+   */
+  public function testUrlIsRewritten(): void {
+    $url = $this->style->buildUrl($this->imageUri);
+    $this->assertStringContainsString('/filefield_paths/image-style/ffp_test/temporary', $url);
+    $this->assertStringContainsString('file=filefield_paths/', $url);
+    $this->assertStringContainsString('itok=', $url);
   }
 
   /**
@@ -95,10 +111,18 @@ class FileFieldPathsImageStyleTemporaryTest extends BrowserTestBase {
   }
 
   /**
-   * Tests private:// temp location leaves private delivery intact.
+   * Tests that accessing the route without a file parameter returns 403.
+   */
+  public function testEmptyFileParamReturns403(): void {
+    $this->drupalGet('/filefield_paths/image-style/ffp_test/temporary');
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+  /**
+   * Tests that non-temporary temp_location does not trigger URL rewriting.
    *
-   * The alter hook only matches temporary:// derivative URIs, so switching
-   * the temp location to private:// must not trigger the FFP temporary route.
+   * When temp_location uses private://, the alter hook must not intercept
+   * derivative URLs, leaving them on the standard private delivery route.
    */
   public function testPrivateTempLocationUnaffected(): void {
     \Drupal::configFactory()
@@ -106,9 +130,8 @@ class FileFieldPathsImageStyleTemporaryTest extends BrowserTestBase {
       ->set('temp_location', 'private://filefield_paths')
       ->save();
 
-    $private_uri = 'private://filefield_paths/image-1.png';
-    $derivative_uri = $this->style->buildUri($private_uri);
-    $this->assertStringStartsWith('private://', $derivative_uri);
+    $url = $this->style->buildUrl($this->imageUri);
+    $this->assertStringNotContainsString('/filefield_paths/image-style/', $url);
   }
 
 }

--- a/tests/src/Functional/FileFieldPathsImageStyleTemporaryTest.php
+++ b/tests/src/Functional/FileFieldPathsImageStyleTemporaryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\image\Entity\ImageStyle;
@@ -14,6 +15,7 @@ use Drupal\Tests\BrowserTestBase;
  *
  * @group filefield_paths
  */
+#[Group('filefield_paths')]
 class FileFieldPathsImageStyleTemporaryTest extends BrowserTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsImageStyleTemporaryTest.php
+++ b/tests/src/Functional/FileFieldPathsImageStyleTemporaryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystemInterface;
@@ -16,6 +17,7 @@ use Drupal\Tests\BrowserTestBase;
  * @group filefield_paths
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsImageStyleTemporaryTest extends BrowserTestBase {
 
   /**

--- a/tests/src/Kernel/FileUrlHooksTest.php
+++ b/tests/src/Kernel/FileUrlHooksTest.php
@@ -9,12 +9,13 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\filefield_paths\Hook\FileUrlHooks;
 
 /**
- * Tests the file_url_alter hook implementation in isolation.
+ * Tests the file_url_alter and file_download hook implementations.
  *
  * The functional test (FileFieldPathsImageStyleTemporaryTest) already
- * exercises this hook via ImageStyle::buildUrl(), but that runs in the same
- * process so it is partially covered there too; this kernel test isolates
- * each branch directly against fileUrlAlter().
+ * exercises these hooks via ImageStyle::buildUrl() and an HTTP derivative
+ * request, but that runs in a separate PHP process so it never registers in
+ * code coverage. This kernel test isolates each branch directly against
+ * fileUrlAlter() and fileDownload().
  *
  * @group filefield_paths
  * @covers \Drupal\filefield_paths\Hook\FileUrlHooks
@@ -84,6 +85,64 @@ class FileUrlHooksTest extends KernelTestBase {
     $this->assertStringContainsString('/filefield_paths/image-style/thumbnail/temporary', $uri);
     $this->assertStringContainsString('file=', $uri);
     $this->assertStringContainsString('filefield_paths', $uri);
+  }
+
+  /**
+   * Non-temporary schemes receive no opinion from fileDownload().
+   */
+  public function testFileDownloadNonTemporarySchemeReturnsNull(): void {
+    $this->setTempLocation('temporary://filefield_paths');
+    $this->assertNull($this->fileUrlHooks->fileDownload('public://filefield_paths/image.png'));
+  }
+
+  /**
+   * Non-temporary temp_location receives no opinion from fileDownload().
+   */
+  public function testFileDownloadNonTemporaryTempLocationReturnsNull(): void {
+    $this->setTempLocation('private://filefield_paths');
+    $this->assertNull($this->fileUrlHooks->fileDownload('temporary://filefield_paths/image.png'));
+  }
+
+  /**
+   * Files outside the FFP subdirectory receive no opinion from fileDownload().
+   */
+  public function testFileDownloadOutsideSubdirReturnsNull(): void {
+    $this->setTempLocation('temporary://filefield_paths');
+    $this->assertNull($this->fileUrlHooks->fileDownload('temporary://other_module/image.png'));
+  }
+
+  /**
+   * Paths inside the FFP subdirectory are granted access by fileDownload().
+   */
+  public function testFileDownloadInsideSubdirGrantsAccess(): void {
+    $this->setTempLocation('temporary://filefield_paths');
+    $result = $this->fileUrlHooks->fileDownload('temporary://filefield_paths/image.png');
+    $this->assertIsArray($result);
+    $this->assertNotEmpty($result);
+    $this->assertSame('inline', $result['Content-Disposition']);
+  }
+
+  /**
+   * Nested paths inside the FFP subdirectory are also granted access.
+   */
+  public function testFileDownloadNestedPathGrantsAccess(): void {
+    $this->setTempLocation('temporary://filefield_paths');
+    $result = $this->fileUrlHooks->fileDownload('temporary://filefield_paths/sub/dir/image.png');
+    $this->assertIsArray($result);
+    $this->assertNotEmpty($result);
+  }
+
+  /**
+   * A different temporary subdir is honoured when temp_location is changed.
+   */
+  public function testFileDownloadCustomSubdir(): void {
+    $this->setTempLocation('temporary://custom_staging');
+    // Outside the configured subdir.
+    $this->assertNull($this->fileUrlHooks->fileDownload('temporary://filefield_paths/image.png'));
+    // Inside the configured subdir.
+    $result = $this->fileUrlHooks->fileDownload('temporary://custom_staging/image.png');
+    $this->assertIsArray($result);
+    $this->assertNotEmpty($result);
   }
 
 }

--- a/tests/src/Kernel/FileUrlHooksTest.php
+++ b/tests/src/Kernel/FileUrlHooksTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\filefield_paths\Hook\FileUrlHooks;
@@ -21,6 +22,7 @@ use Drupal\filefield_paths\Hook\FileUrlHooks;
  * @covers \Drupal\filefield_paths\Hook\FileUrlHooks
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileUrlHooksTest extends KernelTestBase {
 
   /**
@@ -143,6 +145,24 @@ class FileUrlHooksTest extends KernelTestBase {
     $result = $this->fileUrlHooks->fileDownload('temporary://custom_staging/image.png');
     $this->assertIsArray($result);
     $this->assertNotEmpty($result);
+  }
+
+  /**
+   * Derivative URIs for files outside the FFP subdir are not rewritten.
+   */
+  public function testUrlAlterOutsideSubdirIsUnaffected(): void {
+    $this->setTempLocation('temporary://filefield_paths');
+    $uri = 'temporary://styles/thumbnail/temporary/other_module/image.png';
+    $this->fileUrlHooks->fileUrlAlter($uri);
+    $this->assertSame('temporary://styles/thumbnail/temporary/other_module/image.png', $uri);
+  }
+
+  /**
+   * Path traversal in fileDownload() is rejected.
+   */
+  public function testFileDownloadTraversalReturnsNull(): void {
+    $this->setTempLocation('temporary://filefield_paths');
+    $this->assertNull($this->fileUrlHooks->fileDownload('temporary://filefield_paths/../other_module/image.png'));
   }
 
 }

--- a/tests/src/Kernel/FileUrlHooksTest.php
+++ b/tests/src/Kernel/FileUrlHooksTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\filefield_paths\Kernel;
+
+use PHPUnit\Framework\Attributes\Group;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\filefield_paths\Hook\FileUrlHooks;
+
+/**
+ * Tests the file_url_alter hook implementation in isolation.
+ *
+ * The functional test (FileFieldPathsImageStyleTemporaryTest) already
+ * exercises this hook via ImageStyle::buildUrl(), but that runs in the same
+ * process so it is partially covered there too; this kernel test isolates
+ * each branch directly against fileUrlAlter().
+ *
+ * @group filefield_paths
+ * @covers \Drupal\filefield_paths\Hook\FileUrlHooks
+ */
+#[Group('filefield_paths')]
+class FileUrlHooksTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array<string>
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'file',
+    'filefield_paths',
+  ];
+
+  /**
+   * The hook implementation under test.
+   */
+  protected FileUrlHooks $fileUrlHooks;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->fileUrlHooks = $this->container->get(FileUrlHooks::class);
+  }
+
+  /**
+   * Sets the FFP temp location config.
+   */
+  protected function setTempLocation(string $temp_location): void {
+    $this->config('filefield_paths.settings')->set('temp_location', $temp_location)->save();
+  }
+
+  /**
+   * Non-temporary temp_location leaves the URI untouched.
+   */
+  public function testNonTemporarySchemeIsUnaffected(): void {
+    $this->setTempLocation('private://filefield_paths');
+    $uri = 'temporary://styles/thumbnail/temporary/filefield_paths/image.png';
+    $this->fileUrlHooks->fileUrlAlter($uri);
+    $this->assertSame('temporary://styles/thumbnail/temporary/filefield_paths/image.png', $uri);
+  }
+
+  /**
+   * A URI that does not match the temporary style pattern is unaffected.
+   */
+  public function testNonMatchingUriIsUnaffected(): void {
+    $this->setTempLocation('temporary://filefield_paths');
+    $uri = 'temporary://filefield_paths/image.png';
+    $this->fileUrlHooks->fileUrlAlter($uri);
+    $this->assertSame('temporary://filefield_paths/image.png', $uri);
+  }
+
+  /**
+   * A matching temporary style derivative URI is rewritten to the FFP route.
+   */
+  public function testMatchingUriIsRewritten(): void {
+    $this->setTempLocation('temporary://filefield_paths');
+    $uri = 'temporary://styles/thumbnail/temporary/filefield_paths/image.png';
+    $this->fileUrlHooks->fileUrlAlter($uri);
+    $this->assertStringContainsString('/filefield_paths/image-style/thumbnail/temporary', $uri);
+    $this->assertStringContainsString('file=', $uri);
+    $this->assertStringContainsString('filefield_paths', $uri);
+  }
+
+}

--- a/tests/src/Kernel/ImageStyleTemporaryAccessCheckTest.php
+++ b/tests/src/Kernel/ImageStyleTemporaryAccessCheckTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\filefield_paths\Kernel;
+
+use PHPUnit\Framework\Attributes\Group;
+use Drupal\Core\Cache\CacheableDependencyInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\filefield_paths\Access\ImageStyleTemporaryAccessCheck;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests the temporary image style access checker in isolation.
+ *
+ * The functional test (FileFieldPathsImageStyleTemporaryTest) already
+ * exercises this checker over HTTP, but that request is served by a separate
+ * PHP process, so it never registers in code coverage. This kernel test
+ * calls access() directly so every branch is covered in-process.
+ *
+ * @group filefield_paths
+ * @covers \Drupal\filefield_paths\Access\ImageStyleTemporaryAccessCheck
+ */
+#[Group('filefield_paths')]
+class ImageStyleTemporaryAccessCheckTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array<string>
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'file',
+    'filefield_paths',
+  ];
+
+  /**
+   * The access checker under test.
+   */
+  protected ImageStyleTemporaryAccessCheck $accessCheck;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->accessCheck = $this->container->get('filefield_paths.access_checker.image_style_temporary');
+  }
+
+  /**
+   * Sets the FFP temp location config.
+   */
+  protected function setTempLocation(string $temp_location): void {
+    $this->config('filefield_paths.settings')->set('temp_location', $temp_location)->save();
+  }
+
+  /**
+   * An empty ?file= parameter is forbidden.
+   */
+  public function testEmptyFileIsForbidden(): void {
+    $this->setTempLocation('temporary://filefield_paths');
+    $result = $this->accessCheck->access(Request::create('/'));
+    $this->assertTrue($result->isForbidden());
+    if (!$result instanceof CacheableDependencyInterface) {
+      $this->fail('Expected a cacheable access result.');
+    }
+    $this->assertSame(['url.query_args:file'], $result->getCacheContexts());
+    $this->assertSame(['config:filefield_paths.settings'], $result->getCacheTags());
+  }
+
+  /**
+   * A non-temporary temp_location forbids access regardless of ?file=.
+   */
+  public function testNonTemporarySchemeIsForbidden(): void {
+    $this->setTempLocation('private://filefield_paths');
+    $result = $this->accessCheck->access(Request::create('/', 'GET', ['file' => 'filefield_paths/image.png']));
+    $this->assertTrue($result->isForbidden());
+  }
+
+  /**
+   * An empty subdirectory in temp_location forbids access.
+   */
+  public function testEmptySubdirIsForbidden(): void {
+    $this->setTempLocation('temporary://');
+    $result = $this->accessCheck->access(Request::create('/', 'GET', ['file' => 'anything.png']));
+    $this->assertTrue($result->isForbidden());
+  }
+
+  /**
+   * A path traversal sequence in ?file= is forbidden.
+   */
+  public function testPathTraversalIsForbidden(): void {
+    $this->setTempLocation('temporary://filefield_paths');
+    $result = $this->accessCheck->access(Request::create('/', 'GET', ['file' => 'filefield_paths/../etc/passwd']));
+    $this->assertTrue($result->isForbidden());
+  }
+
+  /**
+   * A file outside the configured subdirectory is not allowed.
+   *
+   * AllowedIf(FALSE) returns a neutral result rather than an explicit forbid,
+   * so this asserts isAllowed() rather than isForbidden() (unlike the other
+   * negative cases above, which return AccessResult::forbidden() directly).
+   */
+  public function testFileOutsideSubdirIsNotAllowed(): void {
+    $this->setTempLocation('temporary://filefield_paths');
+    $result = $this->accessCheck->access(Request::create('/', 'GET', ['file' => 'other_module/image.png']));
+    $this->assertFalse($result->isAllowed());
+  }
+
+  /**
+   * A file inside the configured subdirectory is allowed.
+   */
+  public function testFileInsideSubdirIsAllowed(): void {
+    $this->setTempLocation('temporary://filefield_paths');
+    $result = $this->accessCheck->access(Request::create('/', 'GET', ['file' => 'filefield_paths/image.png']));
+    $this->assertTrue($result->isAllowed());
+  }
+
+}

--- a/tests/src/Kernel/ImageStyleTemporaryAccessCheckTest.php
+++ b/tests/src/Kernel/ImageStyleTemporaryAccessCheckTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Cache\CacheableDependencyInterface;
 use Drupal\KernelTests\KernelTestBase;
@@ -22,6 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
  * @covers \Drupal\filefield_paths\Access\ImageStyleTemporaryAccessCheck
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class ImageStyleTemporaryAccessCheckTest extends KernelTestBase {
 
   /**


### PR DESCRIPTION
## Summary

Fixes broken image thumbnails on the node edit form when File (Field) Paths
stages uploaded files in `temporary://`. Image style derivatives are now
generated and served on demand via a dedicated delivery route, so the default
`temporary://filefield_paths` temp location works without switching to
`private://`.

Closes #3121826

## Background

When an image field uses File (Field) Paths, uploaded files are staged in a
temporary location (`temporary://filefield_paths` by default) and moved to
their final path only when the entity is saved. Drupal core's image style
delivery controller does not handle `temporary://` URIs, so derivative URLs
return 404 — causing the "broken thumbnail" symptom reported in the issue.

The workaround was to switch `temp_location` to `private://filefield_paths`,
but this requires the private filesystem to be configured and adds access
overhead that isn't needed in most cases.

## How it works

1. **`hook_file_url_alter()`** — intercepts derivative URIs matching
   `temporary://styles/{style}/temporary/{file}` and rewrites them to a
   dedicated route.
2. **Delivery route** (`/system/files/styles/{image_style}/temporary`) —
   delegates to core's `ImageStyleDownloadController::deliver()` with
   `scheme: temporary`, so derivative generation and `itok` validation work
   exactly as they do for public/private files.
3. **Access checker** (`_ffp_temp_image_style`) — restricts the route to
   files within the configured FFP temp subdirectory, preventing arbitrary
   `temporary://` file access. When `temp_location` uses a non-temporary
   scheme (e.g. `private://`), the checker returns neutral so the normal
   private file delivery path applies.

## Changes

| File | Type | Purpose |
|------|------|---------|
| `src/Hook/FileUrlHooks.php` | New | `hook_file_url_alter()` — rewrites temporary derivative URIs |
| `src/Access/ImageStyleTemporaryAccessCheck.php` | New | Access checker scoped to FFP temp subdirectory |
| `filefield_paths.routing.yml` | Modified | Delivery route for temporary image styles |
| `filefield_paths.services.yml` | Modified | Register access checker + FileUrlHooks service |
| `tests/src/Functional/FileFieldPathsImageStyleTemporaryTest.php` | New | 4 tests: derivative served, itok validation, subdir restriction, private:// unaffected |

## Test plan

- [ ] `DRUPAL_VERSION=10 make lint` passes
- [ ] `DRUPAL_VERSION=10 make test` passes
- [x] Manual: image field with FFP temp location set to `temporary://filefield_paths` — thumbnails appear on node edit form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added on-demand image-style delivery for files in temporary storage.
  - Temporary image URLs are automatically rewritten for derivative generation and delivery.
  - Matching temporary files can be served inline from configured staging directories.

- **Security**
  - Blocks unauthorized paths, missing files, invalid locations, and directory traversal attempts.
  - Private temporary storage remains unaffected.

- **Tests**
  - Added coverage for URL rewriting, derivative delivery, access control, nested paths, and invalid requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->