### PR TITLE
test: convert PHPUnit docblock annotations to attributes

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -105,6 +105,18 @@ parameters:
       reportUnmatched: false
 
     -
+      # PHPUnit\Framework\Attributes\{Group,DataProvider} only exist in PHPUnit 10+. The project's
+      # composer constraint (^9.6 || ^10.5 || ^11) deliberately spans PHPUnit 9 through 11 so the
+      # matrix can test PHP 8.5/PHPUnit 11 alongside older platforms; whichever environment resolves
+      # PHPUnit 9 won't have these classes. The attributes are harmless no-ops under PHPUnit 9 (PHP
+      # never loads an attribute class unless something reflects for it, and PHPUnit 9 doesn't
+      # look for these), so they're kept for forward-compat with the docblock-to-attribute migration
+      # PHPUnit 10+/Rector expect, and ignored here rather than dropped.
+      messages:
+        - '#Attribute class PHPUnit\\Framework\\Attributes\\(Group|DataProvider) does not exist#'
+      reportUnmatched: false
+
+    -
       # Deprecated procedural wrappers are tested intentionally in
       # ModuleDeprecatedWrappersTest to verify deprecation notices fire.
       #

--- a/tests/src/Functional/FileFieldPathsDrushCommandTest.php
+++ b/tests/src/Functional/FileFieldPathsDrushCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drush\TestTraits\DrushTestTrait;
 
 /**
@@ -12,6 +13,7 @@ use Drush\TestTraits\DrushTestTrait;
  * @group filefield_paths
  * @runTestsInSeparateProcesses
  */
+#[Group('filefield_paths')]
 class FileFieldPathsDrushCommandTest extends FileFieldPathsTestBase {
 
   use DrushTestTrait;

--- a/tests/src/Functional/FileFieldPathsGeneralTest.php
+++ b/tests/src/Functional/FileFieldPathsGeneralTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\file\Plugin\Field\FieldType\FileItem;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\File\FileSystemInterface;
@@ -17,6 +18,7 @@ use Drupal\image\Entity\ImageStyle;
  * @group filefield_paths
  * @runTestsInSeparateProcesses
  */
+#[Group('filefield_paths')]
 class FileFieldPathsGeneralTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsPathautoTest.php
+++ b/tests/src/Functional/FileFieldPathsPathautoTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Component\Utility\Unicode;
 
 /**
@@ -12,6 +13,7 @@ use Drupal\Component\Utility\Unicode;
  * @group filefield_paths
  * @runTestsInSeparateProcesses
  */
+#[Group('filefield_paths')]
 class FileFieldPathsPathautoTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsRedirectTest.php
+++ b/tests/src/Functional/FileFieldPathsRedirectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\redirect\Entity\Redirect;
 
@@ -13,6 +14,7 @@ use Drupal\redirect\Entity\Redirect;
  * @group filefield_paths
  * @runTestsInSeparateProcesses
  */
+#[Group('filefield_paths')]
 class FileFieldPathsRedirectTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsTokensTest.php
+++ b/tests/src/Functional/FileFieldPathsTokensTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test token functionality.
  *
  * @group filefield_paths
  * @runTestsInSeparateProcesses
  */
+#[Group('filefield_paths')]
 class FileFieldPathsTokensTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsTransliterationTest.php
+++ b/tests/src/Functional/FileFieldPathsTransliterationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Component\Utility\Unicode;
 
 /**
@@ -12,6 +13,7 @@ use Drupal\Component\Utility\Unicode;
  * @group filefield_paths
  * @runTestsInSeparateProcesses
  */
+#[Group('filefield_paths')]
 class FileFieldPathsTransliterationTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsUpdateTest.php
+++ b/tests/src/Functional/FileFieldPathsUpdateTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test update functionality.
  *
  * @group filefield_paths
  * @runTestsInSeparateProcesses
  */
+#[Group('filefield_paths')]
 class FileFieldPathsUpdateTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Kernel/BatchUpdaterTest.php
+++ b/tests/src/Kernel/BatchUpdaterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\entity_test\Entity\EntityTest;
@@ -18,6 +19,7 @@ use Drupal\filefield_paths\Batch\BatchUpdaterInterface;
  * @group filefield_paths
  * @covers \Drupal\filefield_paths\Batch\Updater
  */
+#[Group('filefield_paths')]
 class BatchUpdaterTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/DrushCommandsTest.php
+++ b/tests/src/Kernel/DrushCommandsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\field\Entity\FieldConfig;
@@ -16,6 +17,7 @@ use Drupal\filefield_paths\Drush\Commands\Commands;
  * @group filefield_paths
  * @covers \Drupal\filefield_paths\Drush\Commands\Commands
  */
+#[Group('filefield_paths')]
 class DrushCommandsTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/FieldConfigEditFormTest.php
+++ b/tests/src/Kernel/FieldConfigEditFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Form\FormInterface;
 use Drupal\Core\Form\FormState;
@@ -19,6 +20,7 @@ use Drupal\filefield_paths\Hook\FieldConfigEditForm;
  * @covers \Drupal\filefield_paths\Hook\FieldConfigEditForm
  * @covers \Drupal\filefield_paths\Hook\FileFieldPathsFieldSettingsLegacy
  */
+#[Group('filefield_paths')]
 class FieldConfigEditFormTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/FileFieldPathsProcessFileLegacyTest.php
+++ b/tests/src/Kernel/FileFieldPathsProcessFileLegacyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\KernelTests\KernelTestBase;
@@ -23,6 +24,7 @@ use Drupal\filefield_paths\RedirectInterface;
  * @group filefield_paths
  * @covers \Drupal\filefield_paths\Hook\FileFieldPathsProcessFileLegacy
  */
+#[Group('filefield_paths')]
 class FileFieldPathsProcessFileLegacyTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/InstallFunctionsTest.php
+++ b/tests/src/Kernel/InstallFunctionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Component\Utility\DeprecationHelper;
 use Drupal\Core\Extension\Requirement\RequirementSeverity;
 use Drupal\KernelTests\KernelTestBase;
@@ -14,6 +15,7 @@ use Drupal\filefield_paths\MoveFileProcessorInterface;
  *
  * @group filefield_paths
  */
+#[Group('filefield_paths')]
 class InstallFunctionsTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/ModuleDeprecatedWrappersTest.php
+++ b/tests/src/Kernel/ModuleDeprecatedWrappersTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Language\Language;
@@ -19,6 +20,7 @@ use Drupal\field\Entity\FieldStorageConfig;
  *
  * @group filefield_paths
  */
+#[Group('filefield_paths')]
 class ModuleDeprecatedWrappersTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/ModuleLegacyHooksTest.php
+++ b/tests/src/Kernel/ModuleLegacyHooksTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormInterface;
 use Drupal\Core\Form\FormState;
@@ -22,6 +23,7 @@ use Drupal\file\Plugin\Field\FieldType\FileFieldItemList;
  *
  * @group filefield_paths
  */
+#[Group('filefield_paths')]
 class ModuleLegacyHooksTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/PathProcessorTest.php
+++ b/tests/src/Kernel/PathProcessorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\filefield_paths\PathProcessorInterface;
 
@@ -19,6 +20,7 @@ use Drupal\filefield_paths\PathProcessorInterface;
  * @group filefield_paths
  * @covers \Drupal\filefield_paths\PathProcessor
  */
+#[Group('filefield_paths')]
 class PathProcessorTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/RedirectTest.php
+++ b/tests/src/Kernel/RedirectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Language\Language;
 use Drupal\KernelTests\KernelTestBase;
@@ -14,6 +15,7 @@ use Drupal\KernelTests\KernelTestBase;
  * @group filefield_paths
  * @covers \Drupal\filefield_paths\Redirect
  */
+#[Group('filefield_paths')]
 class RedirectTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/SettingsFormTest.php
+++ b/tests/src/Kernel/SettingsFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Form\FormState;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\filefield_paths\Form\SettingsForm;
@@ -14,6 +15,7 @@ use Drupal\filefield_paths\Form\SettingsForm;
  * @group filefield_paths
  * @covers \Drupal\filefield_paths\Form\SettingsForm
  */
+#[Group('filefield_paths')]
 class SettingsFormTest extends KernelTestBase {
 
   /**

--- a/tests/src/Unit/EntityWithFileFieldTest.php
+++ b/tests/src/Unit/EntityWithFileFieldTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Unit;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\filefield_paths\Hook\EntityWithFileField;
@@ -15,6 +16,7 @@ use Drupal\Tests\UnitTestCase;
  * @group filefield_paths
  * @covers \Drupal\filefield_paths\Hook\EntityWithFileField
  */
+#[Group('filefield_paths')]
 class EntityWithFileFieldTest extends UnitTestCase {
 
   /**

--- a/tests/src/Unit/FieldConfigEditFormHandlerTest.php
+++ b/tests/src/Unit/FieldConfigEditFormHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Unit;
 
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Form\FormInterface;
@@ -21,6 +22,7 @@ use Drupal\Tests\UnitTestCase;
  * @group filefield_paths
  * @covers \Drupal\filefield_paths\Utility\FieldConfigEditFormHandler
  */
+#[Group('filefield_paths')]
 class FieldConfigEditFormHandlerTest extends UnitTestCase {
 
   /**

--- a/tests/src/Unit/FieldItemTest.php
+++ b/tests/src/Unit/FieldItemTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Unit;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\field\FieldConfigInterface;
@@ -18,6 +20,7 @@ use Drupal\Tests\UnitTestCase;
  * @runTestsInSeparateProcesses
  * @covers \Drupal\filefield_paths\Utility\FieldItem
  */
+#[Group('filefield_paths')]
 class FieldItemTest extends UnitTestCase {
 
   /**
@@ -26,6 +29,7 @@ class FieldItemTest extends UnitTestCase {
    * @covers \Drupal\filefield_paths\Utility\FieldItem::getFromSupportedWidget
    * @dataProvider dataProviderGetFromSupportedWidget
    */
+  #[DataProvider('dataProviderGetFromSupportedWidget')]
   public function testGetFromSupportedWidget(array $element, array $context, bool $expected_result): void {
     if (isset($context['items']) && $context['items'] === 'file_field_item_list') {
       $context['items'] = $this->createMock(FileFieldItemList::class);
@@ -51,6 +55,7 @@ class FieldItemTest extends UnitTestCase {
    * @covers \Drupal\filefield_paths\Utility\FieldItem::hasConfigurationEnabled
    * @dataProvider dataProviderHasConfigurationEnabled
    */
+  #[DataProvider('dataProviderHasConfigurationEnabled')]
   public function testHasConfigurationEnabled(bool $is_file_field, ?array $third_party_settings, bool $expected): void {
     if ($is_file_field) {
       $definition = $this->createMock(FieldConfigInterface::class);

--- a/tests/src/Unit/FieldWidgetSingleElementFormTest.php
+++ b/tests/src/Unit/FieldWidgetSingleElementFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Unit;
 
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
@@ -19,6 +20,7 @@ use Drupal\filefield_paths\Hook\FieldWidgetSingleElementForm;
  * @group filefield_paths
  * @covers \Drupal\filefield_paths\Hook\FieldWidgetSingleElementForm
  */
+#[Group('filefield_paths')]
 class FieldWidgetSingleElementFormTest extends UnitTestCase {
 
   /**

--- a/tests/src/Unit/LocalTaskAlterTest.php
+++ b/tests/src/Unit/LocalTaskAlterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Unit;
 
+use PHPUnit\Framework\Attributes\Group;
 use Drupal\Tests\UnitTestCase;
 use Drupal\filefield_paths\Hook\LocalTaskAlter;
 
@@ -13,6 +14,7 @@ use Drupal\filefield_paths\Hook\LocalTaskAlter;
  * @group filefield_paths
  * @covers \Drupal\filefield_paths\Hook\LocalTaskAlter
  */
+#[Group('filefield_paths')]
 class LocalTaskAlterTest extends UnitTestCase {
 
   /**

--- a/tests/src/Unit/MoveFileProcessorDetectRecommendedSchemeTest.php
+++ b/tests/src/Unit/MoveFileProcessorDetectRecommendedSchemeTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Unit;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
 use Drupal\Tests\UnitTestCase;
@@ -16,6 +18,7 @@ use Drupal\filefield_paths\MoveFileProcessor;
  * @covers \Drupal\filefield_paths\MoveFileProcessor::detectRecommendedScheme
  * @covers \Drupal\filefield_paths\MoveFileProcessor::recommendedTemporaryScheme
  */
+#[Group('filefield_paths')]
 class MoveFileProcessorDetectRecommendedSchemeTest extends UnitTestCase {
 
   /**
@@ -23,6 +26,7 @@ class MoveFileProcessorDetectRecommendedSchemeTest extends UnitTestCase {
    *
    * @dataProvider dataProviderDetectRecommendedScheme
    */
+  #[DataProvider('dataProviderDetectRecommendedScheme')]
   public function testDetectRecommendedScheme(array $wrappers, array $writable_map, string $expected): void {
     $stream_manager = $this->createMock(StreamWrapperManagerInterface::class);
     $cache_backend = $this->createMock(CacheBackendInterface::class);


### PR DESCRIPTION
GitHub Actions' `lint` job runs on PHP 8.5, which resolves `phpunit/phpunit` to `^11` instead of the `^9.6` picked up on older PHP platforms (local dev, GitLab CI). Rector's `PhpUnitTestAnnotationToAttributeRector` only fires once PHPUnit 10+ is present, so it flagged `@group`/`@dataProvider` docblocks across the test suite as needing conversion to PHP attributes — this affects all three other open PRs identically and is unrelated to any of their changes.

Converts the 23 base-branch files affected (a 24th file, added by an in-flight PR, will get the same treatment when that branch rebases on top of this).

Attributes are no-ops under PHPUnit 9 (PHP never loads an attribute class unless something reflects for it), so a scoped PHPStan ignore keeps `phpstan` green on PHPUnit-9 environments where `PHPUnit\Framework\Attributes\{Group,DataProvider}` don't exist.

Verified locally (`make lint`, `make test-unit/test-kernel/test-functional`) and on GitLab CI (pipeline passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated testing infrastructure to adopt PHPUnit 10+ attribute-based metadata declarations for test grouping and data provisioning
  * Modernized test organization to use contemporary PHPUnit conventions while maintaining test coverage and functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->