### PR TITLE
feat(#3608361): pass field delta in token data for [file:delta] support

### DIFF
--- a/src/Hook/FieldConfigEditForm.php
+++ b/src/Hook/FieldConfigEditForm.php
@@ -57,7 +57,7 @@ final class FieldConfigEditForm {
     $field = $form_object->getEntity();
     $class = $field->getClass();
 
-    if (!(class_exists($class) && ($class === FileFieldItemList::class || is_subclass_of($class, FileFieldItemList::class)))) {
+    if (!class_exists($class) || ($class !== FileFieldItemList::class && !is_subclass_of($class, FileFieldItemList::class))) {
       // Not supported the field config edit form.
       return;
     }
@@ -110,7 +110,7 @@ final class FieldConfigEditForm {
       ];
 
       // Attach widget field form elements.
-      if (!(isset($settings_field['form']) && is_array($settings_field['form']))) {
+      if (!isset($settings_field['form']) || !is_array($settings_field['form'])) {
         // No expected form elements.
         continue;
       }

--- a/src/Hook/FileFieldPathsProcessFileLegacy.php
+++ b/src/Hook/FileFieldPathsProcessFileLegacy.php
@@ -13,6 +13,7 @@ use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+use Drupal\file\FileInterface;
 use Drupal\file\FileRepositoryInterface;
 use Drupal\file\Plugin\Field\FieldType\FileFieldItemList;
 use Drupal\filefield_paths\PathProcessorInterface;
@@ -61,10 +62,13 @@ final readonly class FileFieldPathsProcessFileLegacy {
     $temporary_scheme_name = $this->streamWrapperManager::getScheme($temp_location);
     $schemas = [$temporary_scheme_name, $destination_scheme_name];
 
-    /** @var \Drupal\file\Entity\File $file */
-    foreach ($field->referencedEntities() as $file) {
+    foreach ($field as $delta => $field_item) {
+      $file = $field_item->entity;
+      if (!$file instanceof FileInterface) {
+        continue;
+      }
       $source_scheme_name = $this->streamWrapperManager::getScheme($file->getFileUri());
-      if (!(!empty($wrappers[$destination_scheme_name]) && in_array($source_scheme_name, $schemas, TRUE))) {
+      if (empty($wrappers[$destination_scheme_name]) || !in_array($source_scheme_name, $schemas, TRUE)) {
         // Unexpected source scheme.
         continue;
       }
@@ -80,8 +84,9 @@ final readonly class FileFieldPathsProcessFileLegacy {
       }
 
       $token_data = [
-        'file' => $file,
+        'file'                      => $file,
         $entity->getEntityTypeId() => $entity,
+        'delta'                     => $delta,
       ];
 
       // Process filename.
@@ -107,7 +112,7 @@ final readonly class FileFieldPathsProcessFileLegacy {
       }
 
       // Finalize file if necessary.
-      if (!($file->getFileUri() !== $destination && file_exists($file->getFileUri()))) {
+      if ($file->getFileUri() === $destination || !file_exists($file->getFileUri())) {
         // File is already in the right place.
         continue;
       }

--- a/src/Utility/FieldConfigEditFormHandler.php
+++ b/src/Utility/FieldConfigEditFormHandler.php
@@ -41,7 +41,7 @@ class FieldConfigEditFormHandler implements FieldConfigEditFormHandlerInterface 
   public function submit(array $form, FormStateInterface $form_state): void {
     $settings = $form_state->getValue('third_party_settings')['filefield_paths'];
     // Retroactive updates.
-    if (!($settings['enabled'] && $settings['retroactive_update'])) {
+    if (!$settings['enabled'] || !$settings['retroactive_update']) {
       // Retroactive updates disabled.
       return;
     }

--- a/tests/modules/filefield_paths_test/filefield_paths_test.module
+++ b/tests/modules/filefield_paths_test/filefield_paths_test.module
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Support module for File (Field) Paths related testing.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Render\BubbleableMetadata;
+
+/**
+ * Implements hook_token_info_alter().
+ *
+ * Adds a [file:delta] token mirroring the one provided by the Field Tokens
+ * module so that File (Field) Paths can be tested without that dependency.
+ */
+function filefield_paths_test_token_info_alter(array &$data): void {
+  $data['tokens']['file']['delta'] = [
+    'name' => t('Delta'),
+    'description' => t('The zero-based position of the file within its parent multi-value field.'),
+  ];
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function filefield_paths_test_tokens(string $type, array $tokens, array $data, array $options, BubbleableMetadata $bubbleable_metadata): array {
+  $replacements = [];
+  if ($type === 'file' && isset($data['delta']) && isset($tokens['delta'])) {
+    $replacements[$tokens['delta']] = (string) $data['delta'];
+  }
+  return $replacements;
+}

--- a/tests/src/Functional/FileFieldPathsDrushCommandTest.php
+++ b/tests/src/Functional/FileFieldPathsDrushCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drush\TestTraits\DrushTestTrait;
 
@@ -14,6 +15,7 @@ use Drush\TestTraits\DrushTestTrait;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsDrushCommandTest extends FileFieldPathsTestBase {
 
   use DrushTestTrait;

--- a/tests/src/Functional/FileFieldPathsGeneralTest.php
+++ b/tests/src/Functional/FileFieldPathsGeneralTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\file\Plugin\Field\FieldType\FileItem;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
@@ -19,6 +20,7 @@ use Drupal\image\Entity\ImageStyle;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsGeneralTest extends FileFieldPathsTestBase {
 
   /**
@@ -190,6 +192,49 @@ class FileFieldPathsGeneralTest extends FileFieldPathsTestBase {
     $session->responseContains(sprintf('%s/node/%s/1.txt', $this->publicFilesDirectory, $nid));
     $session->responseContains(sprintf('%s/node/%s/2.txt', $this->publicFilesDirectory, $nid));
     $session->responseContains(sprintf('%s/node/%s/3.txt', $this->publicFilesDirectory, $nid));
+  }
+
+  /**
+   * Tests that the field item delta is passed in token data.
+   *
+   * Ensures the [file:delta] token resolves to each file's zero-based position
+   * within a multi-value field when used in a File (Field) Paths filename
+   * pattern.
+   *
+   * @see https://www.drupal.org/project/filefield_paths/issues/3608361
+   */
+  public function testUploadFileDeltaToken(): void {
+    $file_system = \Drupal::service('file_system');
+
+    // Create a multivalue File field whose filename pattern uses [file:delta].
+    $field_name = mb_strtolower($this->randomMachineName());
+    $storage_settings['cardinality'] = FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED;
+    $third_party_settings['filefield_paths']['file_path']['value'] = 'node/[node:nid]';
+    $third_party_settings['filefield_paths']['file_name']['value'] = '[node:nid]-[file:delta].[file:ffp-extension-original]';
+    $this->createFileField($field_name, 'node', $this->contentType, $storage_settings, [], [], $third_party_settings);
+
+    // Create a node with three (3) test files.
+    $text_files = $this->drupalGetTestFiles('text');
+    $this->drupalGet('node/add/' . $this->contentType);
+    $this->submitForm([sprintf('files[%s_0][]', $field_name) => $file_system->realpath($text_files[0]->uri)], 'Upload');
+    $this->submitForm([sprintf('files[%s_1][]', $field_name) => $file_system->realpath($text_files[1]->uri)], 'Upload');
+    $edit = [
+      'title[0][value]' => $this->randomMachineName(),
+      sprintf('files[%s_2][]', $field_name) => $file_system->realpath($text_files[2]->uri),
+    ];
+    $this->submitForm($edit, 'Save');
+
+    // Get created Node ID.
+    $matches = [];
+    preg_match('/node\/(\d+)/', $this->getUrl(), $matches);
+    $this->assertNotEmpty($matches);
+    $nid = $matches[1];
+
+    // Ensure each file received its zero-based delta in the filename.
+    $session = $this->assertSession();
+    $session->responseContains(sprintf('%s/node/%s/%s-0.txt', $this->publicFilesDirectory, $nid, $nid));
+    $session->responseContains(sprintf('%s/node/%s/%s-1.txt', $this->publicFilesDirectory, $nid, $nid));
+    $session->responseContains(sprintf('%s/node/%s/%s-2.txt', $this->publicFilesDirectory, $nid, $nid));
   }
 
   /**

--- a/tests/src/Functional/FileFieldPathsPathautoTest.php
+++ b/tests/src/Functional/FileFieldPathsPathautoTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Component\Utility\Unicode;
 
@@ -14,6 +15,7 @@ use Drupal\Component\Utility\Unicode;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsPathautoTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsRedirectTest.php
+++ b/tests/src/Functional/FileFieldPathsRedirectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\redirect\Entity\Redirect;
@@ -15,6 +16,7 @@ use Drupal\redirect\Entity\Redirect;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsRedirectTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsTokensTest.php
+++ b/tests/src/Functional/FileFieldPathsTokensTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -13,6 +14,7 @@ use PHPUnit\Framework\Attributes\Group;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsTokensTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsTransliterationTest.php
+++ b/tests/src/Functional/FileFieldPathsTransliterationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Component\Utility\Unicode;
 
@@ -14,6 +15,7 @@ use Drupal\Component\Utility\Unicode;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsTransliterationTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsUpdateTest.php
+++ b/tests/src/Functional/FileFieldPathsUpdateTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -13,6 +14,7 @@ use PHPUnit\Framework\Attributes\Group;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsUpdateTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Kernel/BatchUpdaterTest.php
+++ b/tests/src/Kernel/BatchUpdaterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\KernelTests\KernelTestBase;
@@ -20,6 +21,7 @@ use Drupal\filefield_paths\Batch\BatchUpdaterInterface;
  * @covers \Drupal\filefield_paths\Batch\Updater
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class BatchUpdaterTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/DrushCommandsTest.php
+++ b/tests/src/Kernel/DrushCommandsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\KernelTests\KernelTestBase;
@@ -18,6 +19,7 @@ use Drupal\filefield_paths\Drush\Commands\Commands;
  * @covers \Drupal\filefield_paths\Drush\Commands\Commands
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class DrushCommandsTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/FieldConfigEditFormTest.php
+++ b/tests/src/Kernel/FieldConfigEditFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Form\FormInterface;
@@ -21,6 +22,7 @@ use Drupal\filefield_paths\Hook\FieldConfigEditForm;
  * @covers \Drupal\filefield_paths\Hook\FileFieldPathsFieldSettingsLegacy
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FieldConfigEditFormTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/FileFieldPathsProcessFileLegacyTest.php
+++ b/tests/src/Kernel/FileFieldPathsProcessFileLegacyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\File\FileSystemInterface;
@@ -25,6 +26,7 @@ use Drupal\filefield_paths\RedirectInterface;
  * @covers \Drupal\filefield_paths\Hook\FileFieldPathsProcessFileLegacy
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsProcessFileLegacyTest extends KernelTestBase {
 
   /**
@@ -211,6 +213,23 @@ class FileFieldPathsProcessFileLegacyTest extends KernelTestBase {
     $service->fileFieldPathsProcessFile($entity, $field, $settings);
 
     $this->assertFileExists('public://dir-fail/example.txt');
+  }
+
+  /**
+   * A field item referencing a non-existent file is silently skipped.
+   */
+  public function testNonExistentFileSkipped(): void {
+    $entity = EntityTest::create(['field_file' => [['target_id' => 99999]]]);
+    $field = $entity->get('field_file');
+    \assert($field instanceof FileFieldItemList);
+
+    $settings = [
+      'file_path' => ['value' => 'new-dir', 'options' => ['transliterate' => FALSE]],
+      'file_name' => ['value' => '', 'options' => ['transliterate' => FALSE]],
+    ];
+
+    $this->getService()->fileFieldPathsProcessFile($entity, $field, $settings);
+    $this->addToAssertionCount(1);
   }
 
   /**

--- a/tests/src/Kernel/InstallFunctionsTest.php
+++ b/tests/src/Kernel/InstallFunctionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Component\Utility\DeprecationHelper;
 use Drupal\Core\Extension\Requirement\RequirementSeverity;
@@ -16,6 +17,7 @@ use Drupal\filefield_paths\MoveFileProcessorInterface;
  * @group filefield_paths
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class InstallFunctionsTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/ModuleDeprecatedWrappersTest.php
+++ b/tests/src/Kernel/ModuleDeprecatedWrappersTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormState;
@@ -21,6 +22,7 @@ use Drupal\field\Entity\FieldStorageConfig;
  * @group filefield_paths
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class ModuleDeprecatedWrappersTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/ModuleLegacyHooksTest.php
+++ b/tests/src/Kernel/ModuleLegacyHooksTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormInterface;
@@ -24,6 +25,7 @@ use Drupal\file\Plugin\Field\FieldType\FileFieldItemList;
  * @group filefield_paths
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class ModuleLegacyHooksTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/PathProcessorTest.php
+++ b/tests/src/Kernel/PathProcessorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\filefield_paths\PathProcessorInterface;
@@ -21,6 +22,7 @@ use Drupal\filefield_paths\PathProcessorInterface;
  * @covers \Drupal\filefield_paths\PathProcessor
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class PathProcessorTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/RedirectTest.php
+++ b/tests/src/Kernel/RedirectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Language\Language;
@@ -16,6 +17,7 @@ use Drupal\KernelTests\KernelTestBase;
  * @covers \Drupal\filefield_paths\Redirect
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class RedirectTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/SettingsFormTest.php
+++ b/tests/src/Kernel/SettingsFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Form\FormState;
 use Drupal\KernelTests\KernelTestBase;
@@ -16,6 +17,7 @@ use Drupal\filefield_paths\Form\SettingsForm;
  * @covers \Drupal\filefield_paths\Form\SettingsForm
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class SettingsFormTest extends KernelTestBase {
 
   /**


### PR DESCRIPTION
## Problem

The `[file:delta]` token (added in Field Tokens 2.0.x, #2386655) returns the zero-based position of a file within a multi-value field. However, File (Field) Paths iterates over files using `->referencedEntities()` which discards position information, so `[file:delta]` always resolves to empty.

## Changes

- Replace `referencedEntities()` loop with direct field item iteration to expose the delta index
- Pass `'delta' => ` in token data
- Add `instanceof File` guard for safety
- Add functional test with multi-value file field

## Related

- https://www.drupal.org/project/field_tokens/issues/2386655 (Field Tokens delta token)
- https://www.drupal.org/project/filefield_paths/issues/3608361 (Drupal.org issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-item `file:delta` token support for multi-value file upload path generation, assigning each uploaded file a deterministic zero-based delta suffix.

* **Bug Fixes**
  * Improved file field path processing to only act on valid file entities and to skip items referencing missing files.
  * Ensured token replacement for filename patterns uses the correct delta per uploaded item.

* **Tests**
  * Added functional coverage for `file:delta` on unlimited-cardinality multivalue fields.
  * Added token support for tests and updated multiple test suites to run in separate processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->