### PR TITLE
fix: resolve phpstan and rector deprecation warnings

### DIFF
--- a/filefield_paths.install
+++ b/filefield_paths.install
@@ -96,7 +96,7 @@ function filefield_paths_requirements(string $phase): array {
           'title' => t('File (Field) Paths temporary path'),
           'value' => t('Insecure!'),
           'description' => t('This site supports private files but the File (Field) Paths temporary path is under public:// which could lead to private files being temporarily exposed publicly. <a href=":url">Change the temporary path</a> to be under temporary:// or private:// in order to secure your files.', [':url' => Url::fromRoute('filefield_paths.admin_settings')->toString()]),
-          'severity' => DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn(): RequirementSeverity => RequirementSeverity::Error, fn() => REQUIREMENT_ERROR),
+          'severity' => DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn(): RequirementSeverity => RequirementSeverity::Error, fn(): int => REQUIREMENT_ERROR),
         ];
       }
     }

--- a/rector.php
+++ b/rector.php
@@ -17,9 +17,7 @@
 declare(strict_types=1);
 
 use DrupalFinder\DrupalFinderComposerRuntime;
-use DrupalRector\Set\Drupal10SetList;
-use DrupalRector\Set\Drupal11SetList;
-use DrupalRector\Set\Drupal9SetList;
+use DrupalRector\Set\DrupalSetProvider;
 use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
 use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
@@ -27,7 +25,6 @@ use Rector\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
-use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
@@ -41,7 +38,6 @@ use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
 use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
-use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
 return RectorConfig::configure()
@@ -50,8 +46,6 @@ return RectorConfig::configure()
     CatchExceptionNameMatchingTypeRector::class,
     ChangeSwitchToMatchRector::class,
     CompleteDynamicPropertiesRector::class,
-    CountArrayToEmptyArrayComparisonRector::class,
-    DisallowedEmptyRuleFixerRector::class,
     InlineArrayReturnAssignRector::class,
     // Drupal entities use __isset() magic for field access; property_exists()
     // returns false for entity fields, breaking the origname/filename logic.
@@ -89,12 +83,11 @@ return RectorConfig::configure()
     privatization: TRUE,
     naming: TRUE,
   )
-  // Drupal-specific deprecation fixes.
-  ->withSets([
-    Drupal9SetList::DRUPAL_9,
-    Drupal10SetList::DRUPAL_10,
-    Drupal11SetList::DRUPAL_11,
-  ])
+  // Drupal-specific deprecation fixes. The provider binds each set to a
+  // drupal/core version and only loads sets the installed core satisfies,
+  // avoiding hardcoded constants removed in newer rector/rector releases.
+  ->withSetProviders(DrupalSetProvider::class)
+  ->withComposerBased(drupal: TRUE)
   // Additional rules.
   ->withRules([
     DeclareStrictTypesRector::class,

--- a/src/Hook/FieldConfigEditForm.php
+++ b/src/Hook/FieldConfigEditForm.php
@@ -57,7 +57,7 @@ final class FieldConfigEditForm {
     $field = $form_object->getEntity();
     $class = $field->getClass();
 
-    if (!(class_exists($class) && ($class === FileFieldItemList::class || is_subclass_of($class, FileFieldItemList::class)))) {
+    if (!class_exists($class) || $class !== FileFieldItemList::class && !is_subclass_of($class, FileFieldItemList::class)) {
       // Not supported the field config edit form.
       return;
     }
@@ -110,7 +110,7 @@ final class FieldConfigEditForm {
       ];
 
       // Attach widget field form elements.
-      if (!(isset($settings_field['form']) && is_array($settings_field['form']))) {
+      if (!isset($settings_field['form']) || !is_array($settings_field['form'])) {
         // No expected form elements.
         continue;
       }

--- a/src/Hook/FileFieldPathsProcessFileLegacy.php
+++ b/src/Hook/FileFieldPathsProcessFileLegacy.php
@@ -64,7 +64,7 @@ final readonly class FileFieldPathsProcessFileLegacy {
     /** @var \Drupal\file\Entity\File $file */
     foreach ($field->referencedEntities() as $file) {
       $source_scheme_name = $this->streamWrapperManager::getScheme($file->getFileUri());
-      if (!(!empty($wrappers[$destination_scheme_name]) && in_array($source_scheme_name, $schemas, TRUE))) {
+      if (empty($wrappers[$destination_scheme_name]) || !in_array($source_scheme_name, $schemas, TRUE)) {
         // Unexpected source scheme.
         continue;
       }
@@ -107,7 +107,7 @@ final readonly class FileFieldPathsProcessFileLegacy {
       }
 
       // Finalize file if necessary.
-      if (!($file->getFileUri() !== $destination && file_exists($file->getFileUri()))) {
+      if ($file->getFileUri() === $destination || !file_exists($file->getFileUri())) {
         // File is already in the right place.
         continue;
       }

--- a/src/Redirect.php
+++ b/src/Redirect.php
@@ -18,16 +18,9 @@ use Psr\Log\LoggerInterface;
 class Redirect implements RedirectInterface {
 
   /**
-   * The redirect storage.
-   *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
-   */
-  protected $redirectStorage;
-
-  /**
    * Constructs a new redirect service.
    *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
    * @param \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface $streamWrapperManager
    *   The stream wrapper manager.
@@ -36,9 +29,7 @@ class Redirect implements RedirectInterface {
    * @param \Psr\Log\LoggerInterface $logger
    *   The logger service.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, protected StreamWrapperManagerInterface $streamWrapperManager, protected ConfigFactoryInterface $configFactory, protected LoggerInterface $logger) {
-    $this->redirectStorage = $entity_type_manager->getStorage('redirect');
-  }
+  public function __construct(protected EntityTypeManagerInterface $entityTypeManager, protected StreamWrapperManagerInterface $streamWrapperManager, protected ConfigFactoryInterface $configFactory, protected LoggerInterface $logger) {}
 
   /**
    * {@inheritdoc}
@@ -49,8 +40,11 @@ class Redirect implements RedirectInterface {
       '@path'   => $path,
     ]);
 
+    /** @var \Drupal\Core\Entity\EntityStorageInterface $storage */
+    $storage = $this->entityTypeManager->getStorage('redirect');
+
     /** @var \Drupal\redirect\Entity\Redirect $redirect */
-    $redirect = $this->redirectStorage->create([]);
+    $redirect = $storage->create([]);
 
     $parsed_source = $this->getPath($source);
     $parsed_path = $this->getPath($path);
@@ -61,7 +55,7 @@ class Redirect implements RedirectInterface {
 
     // Check if the redirect doesn't already exist before saving.
     $hash = $redirect->generateHash($parsed_path, [], $language->getId());
-    $redirects = $this->redirectStorage->loadByProperties(['hash' => $hash]);
+    $redirects = $storage->loadByProperties(['hash' => $hash]);
     if (empty($redirects)) {
       // Redirect does not exist yet, save as new one.
       $redirect->save();

--- a/src/Utility/FieldConfigEditFormHandler.php
+++ b/src/Utility/FieldConfigEditFormHandler.php
@@ -41,7 +41,7 @@ class FieldConfigEditFormHandler implements FieldConfigEditFormHandlerInterface 
   public function submit(array $form, FormStateInterface $form_state): void {
     $settings = $form_state->getValue('third_party_settings')['filefield_paths'];
     // Retroactive updates.
-    if (!($settings['enabled'] && $settings['retroactive_update'])) {
+    if (!$settings['enabled'] || !$settings['retroactive_update']) {
       // Retroactive updates disabled.
       return;
     }

--- a/tests/src/Functional/FileFieldPathsDrushCommandTest.php
+++ b/tests/src/Functional/FileFieldPathsDrushCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drush\TestTraits\DrushTestTrait;
 
@@ -14,6 +15,7 @@ use Drush\TestTraits\DrushTestTrait;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsDrushCommandTest extends FileFieldPathsTestBase {
 
   use DrushTestTrait;

--- a/tests/src/Functional/FileFieldPathsGeneralTest.php
+++ b/tests/src/Functional/FileFieldPathsGeneralTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\file\Plugin\Field\FieldType\FileItem;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
@@ -19,6 +20,7 @@ use Drupal\image\Entity\ImageStyle;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsGeneralTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsPathautoTest.php
+++ b/tests/src/Functional/FileFieldPathsPathautoTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Component\Utility\Unicode;
 
@@ -14,6 +15,7 @@ use Drupal\Component\Utility\Unicode;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsPathautoTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsRedirectTest.php
+++ b/tests/src/Functional/FileFieldPathsRedirectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\redirect\Entity\Redirect;
@@ -15,6 +16,7 @@ use Drupal\redirect\Entity\Redirect;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsRedirectTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsTokensTest.php
+++ b/tests/src/Functional/FileFieldPathsTokensTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -13,6 +14,7 @@ use PHPUnit\Framework\Attributes\Group;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsTokensTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsTransliterationTest.php
+++ b/tests/src/Functional/FileFieldPathsTransliterationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Component\Utility\Unicode;
 
@@ -14,6 +15,7 @@ use Drupal\Component\Utility\Unicode;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsTransliterationTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Functional/FileFieldPathsUpdateTest.php
+++ b/tests/src/Functional/FileFieldPathsUpdateTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Functional;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -13,6 +14,7 @@ use PHPUnit\Framework\Attributes\Group;
  * @runTestsInSeparateProcesses
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsUpdateTest extends FileFieldPathsTestBase {
 
   /**

--- a/tests/src/Kernel/BatchUpdaterTest.php
+++ b/tests/src/Kernel/BatchUpdaterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\KernelTests\KernelTestBase;
@@ -20,6 +21,7 @@ use Drupal\filefield_paths\Batch\BatchUpdaterInterface;
  * @covers \Drupal\filefield_paths\Batch\Updater
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class BatchUpdaterTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/DrushCommandsTest.php
+++ b/tests/src/Kernel/DrushCommandsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\KernelTests\KernelTestBase;
@@ -18,6 +19,7 @@ use Drupal\filefield_paths\Drush\Commands\Commands;
  * @covers \Drupal\filefield_paths\Drush\Commands\Commands
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class DrushCommandsTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/FieldConfigEditFormTest.php
+++ b/tests/src/Kernel/FieldConfigEditFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Form\FormInterface;
@@ -21,6 +22,7 @@ use Drupal\filefield_paths\Hook\FieldConfigEditForm;
  * @covers \Drupal\filefield_paths\Hook\FileFieldPathsFieldSettingsLegacy
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FieldConfigEditFormTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/FileFieldPathsProcessFileLegacyTest.php
+++ b/tests/src/Kernel/FileFieldPathsProcessFileLegacyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\File\FileSystemInterface;
@@ -25,6 +26,7 @@ use Drupal\filefield_paths\RedirectInterface;
  * @covers \Drupal\filefield_paths\Hook\FileFieldPathsProcessFileLegacy
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class FileFieldPathsProcessFileLegacyTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/InstallFunctionsTest.php
+++ b/tests/src/Kernel/InstallFunctionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Component\Utility\DeprecationHelper;
 use Drupal\Core\Extension\Requirement\RequirementSeverity;
@@ -16,6 +17,7 @@ use Drupal\filefield_paths\MoveFileProcessorInterface;
  * @group filefield_paths
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class InstallFunctionsTest extends KernelTestBase {
 
   /**
@@ -55,7 +57,7 @@ class InstallFunctionsTest extends KernelTestBase {
     $requirements = filefield_paths_requirements('runtime');
 
     $this->assertArrayHasKey('filefield_paths', $requirements);
-    $this->assertSame(DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn(): RequirementSeverity => RequirementSeverity::Error, fn() => REQUIREMENT_ERROR), $requirements['filefield_paths']['severity']);
+    $this->assertSame(DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn(): RequirementSeverity => RequirementSeverity::Error, fn(): int => REQUIREMENT_ERROR), $requirements['filefield_paths']['severity']);
   }
 
   /**

--- a/tests/src/Kernel/ModuleDeprecatedWrappersTest.php
+++ b/tests/src/Kernel/ModuleDeprecatedWrappersTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormState;
@@ -21,6 +22,7 @@ use Drupal\field\Entity\FieldStorageConfig;
  * @group filefield_paths
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class ModuleDeprecatedWrappersTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/ModuleLegacyHooksTest.php
+++ b/tests/src/Kernel/ModuleLegacyHooksTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormInterface;
@@ -24,6 +25,7 @@ use Drupal\file\Plugin\Field\FieldType\FileFieldItemList;
  * @group filefield_paths
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class ModuleLegacyHooksTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/PathProcessorTest.php
+++ b/tests/src/Kernel/PathProcessorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\filefield_paths\PathProcessorInterface;
@@ -21,6 +22,7 @@ use Drupal\filefield_paths\PathProcessorInterface;
  * @covers \Drupal\filefield_paths\PathProcessor
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class PathProcessorTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/RedirectTest.php
+++ b/tests/src/Kernel/RedirectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Language\Language;
@@ -16,6 +17,7 @@ use Drupal\KernelTests\KernelTestBase;
  * @covers \Drupal\filefield_paths\Redirect
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class RedirectTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/SettingsFormTest.php
+++ b/tests/src/Kernel/SettingsFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\filefield_paths\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Group;
 use Drupal\Core\Form\FormState;
 use Drupal\KernelTests\KernelTestBase;
@@ -16,6 +17,7 @@ use Drupal\filefield_paths\Form\SettingsForm;
  * @covers \Drupal\filefield_paths\Form\SettingsForm
  */
 #[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
 class SettingsFormTest extends KernelTestBase {
 
   /**


### PR DESCRIPTION
## Summary

Fixes PHPStan and Rector deprecation/config errors that were blocking CI pipelines, and applies all resulting Rector code transformations.

## Changes

### PHPStan fix

**`src/Redirect.php`** — `drupal.entityStoragePropertyAssignment`
Store `EntityTypeManagerInterface` as a constructor property and call `getStorage('redirect')` at the call site, as recommended by `mglaman/phpstan-drupal`. Removes the `$redirectStorage` property entirely.

### Rector config overhaul

**`rector.php`** — Fix broken configuration caused by incompatibility between `palantirnet/drupal-rector:1.1.2` and `rector/rector:2.6.2`:

- Removed deprecated `CountArrayToEmptyArrayComparisonRector` and `DisallowedEmptyRuleFixerRector` (deprecated, no replacement; PHPCS covers these)
- Removed `Drupal9SetList::DRUPAL_9` (references removed `PHPUnitSetList::PHPUNIT_90`)
- Replaced hardcoded `Drupal10SetList::DRUPAL_10` / `Drupal11SetList::DRUPAL_11` aggregator sets with `DrupalSetProvider` + `withComposerBased(drupal: TRUE)`, aligning with the upstream scaffold (AlexSkrypnyk/drupal_extension_scaffold 1.x). This resolves crashes from constants removed in newer rector/rector (`TwigSetList::TWIG_24`, `SymfonySetList::SYMFONY_63`, `PHPUnitSetList::PHPUNIT_90`) that drupal-rector's version-specific set files still reference.

### Rector-applied code transformations

With the config fixed, Rector now runs successfully and the following transformations were applied to satisfy `rector --dry-run` in CI:

**`PhpUnitAddRunTestsInSeparateProcessesAttributeRector`** (17 test files):
Added `#[RunTestsInSeparateProcesses]` PHP 8 attribute + corresponding `use` statement, modernizing from the docblock `@runTestsInSeparateProcesses` annotation.

**`NegatedAndsToPositiveOrsRector` + `SimplifyDeMorganBinaryRector`** (3 source files):
Simplified double-negated boolean conditions using De Morgan's laws:
- `src/Utility/FieldConfigEditFormHandler.php`
- `src/Hook/FieldConfigEditForm.php`
- `src/Hook/FileFieldPathsProcessFileLegacy.php`

**Type declarations** (2 files):
Added `: int` return type to closures returning `REQUIREMENT_ERROR`:
- `filefield_paths.install`
- `tests/src/Kernel/InstallFunctionsTest.php`
