### PR TITLE
fix(#3015137): point the field item at the moved file

### DIFF
--- a/src/Hook/FileFieldPathsProcessFileLegacy.php
+++ b/src/Hook/FileFieldPathsProcessFileLegacy.php
@@ -62,7 +62,7 @@ final readonly class FileFieldPathsProcessFileLegacy {
     $schemas = [$temporary_scheme_name, $destination_scheme_name];
 
     /** @var \Drupal\file\Entity\File $file */
-    foreach ($field->referencedEntities() as $file) {
+    foreach ($field->referencedEntities() as $delta => $file) {
       $source_scheme_name = $this->streamWrapperManager::getScheme($file->getFileUri());
       if (empty($wrappers[$destination_scheme_name]) || !in_array($source_scheme_name, $schemas, TRUE)) {
         // Unexpected source scheme.
@@ -149,6 +149,17 @@ final readonly class FileFieldPathsProcessFileLegacy {
           break;
         }
         array_pop($paths);
+      }
+
+      // Point the field item at the moved file. Modules that act later in the
+      // same save read the file from the field item, which may be a different
+      // object than this one. Without this they read a path that no longer
+      // exists. This is what breaks Focal Point on the first save.
+      $file->setFileUri($new_file->getFileUri());
+      $file->setFilename($new_file->getFilename());
+      $item = $field->get($delta);
+      if ($item !== NULL) {
+        $item->set('entity', $new_file);
       }
     }
   }

--- a/tests/src/Kernel/FileFieldPathsProcessFileLegacyTest.php
+++ b/tests/src/Kernel/FileFieldPathsProcessFileLegacyTest.php
@@ -146,6 +146,120 @@ class FileFieldPathsProcessFileLegacyTest extends KernelTestBase {
   }
 
   /**
+   * The entity's file object is updated to the moved location.
+   *
+   * A hook_entity_insert() implementation that runs after this module reads
+   * the file object cached on the field item. Focal Point does this. If the
+   * object still holds the pre-move URI, that module writes its own data
+   * against a path that no longer exists.
+   *
+   * @see https://www.drupal.org/i/3015137
+   */
+  public function testMoveUpdatesFileObjectHeldByTheEntity(): void {
+    $file = $this->createFile('public://stale-old/example.txt');
+
+    $entity = EntityTest::create(['field_file' => [['target_id' => $file->id()]]]);
+    $field = $entity->get('field_file');
+    assert($field instanceof FileFieldItemList);
+
+    // Resolve the referenced file before the move. ImageItem::preSave() does
+    // this to read the image dimensions, so the field item holds the object
+    // before any insert hook runs.
+    $referenced = $entity->get('field_file')->entity;
+    $this->assertInstanceOf(File::class, $referenced);
+    $this->assertSame('public://stale-old/example.txt', $referenced->getFileUri());
+
+    $settings = [
+      'file_path' => ['value' => 'stale-new', 'options' => ['transliterate' => FALSE]],
+      'file_name' => ['value' => '', 'options' => ['transliterate' => FALSE]],
+    ];
+    $this->getService()->fileFieldPathsProcessFile($entity, $field, $settings);
+
+    $this->assertFileExists('public://stale-new/example.txt');
+
+    // A later hook implementation reads the same cached object.
+    $after_move = $entity->get('field_file')->entity;
+    $this->assertInstanceOf(File::class, $after_move);
+    $this->assertSame('public://stale-new/example.txt', $after_move->getFileUri());
+  }
+
+  /**
+   * The entity's file object matches the stored record after a rename.
+   *
+   * The move renames around a file that already holds the destination path, so
+   * the stored record can differ from the path that was asked for. The
+   * in-memory object must still agree with what was written to the database.
+   *
+   * @see https://www.drupal.org/i/3015137
+   */
+  public function testMovedFileObjectMatchesStoredRecordOnRename(): void {
+    $file = $this->createFile('public://rename-old/example.txt');
+    // Occupy the destination so the move has to rename around it.
+    $this->createFile('public://rename-new/example.txt', 'occupied');
+
+    $entity = EntityTest::create(['field_file' => [['target_id' => $file->id()]]]);
+    $field = $entity->get('field_file');
+    assert($field instanceof FileFieldItemList);
+
+    $referenced = $entity->get('field_file')->entity;
+    $this->assertInstanceOf(File::class, $referenced);
+
+    $settings = [
+      'file_path' => ['value' => 'rename-new', 'options' => ['transliterate' => FALSE]],
+      'file_name' => ['value' => '', 'options' => ['transliterate' => FALSE]],
+    ];
+    $this->getService()->fileFieldPathsProcessFile($entity, $field, $settings);
+
+    $stored = $this->container->get('entity_type.manager')
+      ->getStorage('file')
+      ->loadUnchanged((int) $file->id());
+    $this->assertInstanceOf(File::class, $stored);
+    $this->assertNotSame('public://rename-old/example.txt', $stored->getFileUri());
+    $this->assertSame($stored->getFileUri(), $referenced->getFileUri());
+    $this->assertSame($stored->getFilename(), $referenced->getFilename());
+  }
+
+  /**
+   * The field item is updated even when it holds a different file instance.
+   *
+   * On a real upload the file object cached on the field item is not always the
+   * same instance that referencedEntities() returns during processing. Focal
+   * Point reads the field item, so updating only the processed instance is not
+   * enough. Here the file static cache is reset after the entity caches its
+   * reference, so the two diverge, the way they do behind the widget.
+   *
+   * @see https://www.drupal.org/i/3015137
+   */
+  public function testMoveUpdatesFieldItemWhenReferencedInstanceDiffers(): void {
+    $file = $this->createFile('public://divergent-old/example.txt');
+
+    $entity = EntityTest::create(['field_file' => [['target_id' => $file->id()]]]);
+    $field = $entity->get('field_file');
+    assert($field instanceof FileFieldItemList);
+
+    // Cache the field item's reference, as ImageItem::preSave() does.
+    $cached = $entity->get('field_file')->entity;
+    $this->assertInstanceOf(File::class, $cached);
+    $this->assertSame('public://divergent-old/example.txt', $cached->getFileUri());
+
+    // Reset the file cache so processing loads a different File instance.
+    $this->container->get('entity_type.manager')->getStorage('file')->resetCache([(int) $file->id()]);
+
+    $settings = [
+      'file_path' => ['value' => 'divergent-new', 'options' => ['transliterate' => FALSE]],
+      'file_name' => ['value' => '', 'options' => ['transliterate' => FALSE]],
+    ];
+    $this->getService()->fileFieldPathsProcessFile($entity, $field, $settings);
+
+    $this->assertFileExists('public://divergent-new/example.txt');
+
+    // What a later hook reads from the field item must be the moved file.
+    $after_move = $entity->get('field_file')->entity;
+    $this->assertInstanceOf(File::class, $after_move);
+    $this->assertSame('public://divergent-new/example.txt', $after_move->getFileUri());
+  }
+
+  /**
    * Returns the hook service under test.
    */
   protected function getService(): FileFieldPathsProcessFileLegacy {


### PR DESCRIPTION
Fixes the 2018 report that File (Field) Paths breaks Focal Point: a focal point set on upload is lost on the first save and correct on the second.

Upstream issue: https://www.drupal.org/i/3015137

## Root cause

After moving a file into its token based path, File (Field) Paths left the field item pointing at the pre-move file object. Modules that act later in the same save read the file from the field item, so they read a path that no longer exists.

Focal Point is the visible casualty. It runs right after us on `hook_entity_insert()`, reads the field item, and saves its crop against the old location. On the second save the file is already in place, so nothing moves and Focal Point reads the right path, which is why the re-save works.

This is not Focal Point specific. Any module reading a file path from the entity in a later hook hits the same thing.

## The change

Point the field item at the moved file once the move is finished:

```php
$item = $field->get($delta);
if ($item !== NULL) {
  $item->set('entity', $new_file);
}
```

It runs after the redirect and directory cleanup, which read the old path on purpose. No dependency on Crop or Focal Point.

An earlier version of this fix only synced the local file variable. That passed a simple save but not the real widget flow, where the upload is staged and reloaded so the field item holds a different File instance than the one being processed. Manual browser testing with Focal Point 2.1.2 and Crop 2.6 caught it. The fix now updates the field item itself, and a kernel test forces that object swap so the gap cannot pass unnoticed again.

## Tests

Two kernel tests in `FileFieldPathsProcessFileLegacyTest`, written before the fix:

- `testMoveUpdatesFileObjectHeldByTheEntity`: a later hook reads the moved path.
- `testMoveUpdatesFieldItemWhenReferencedInstanceDiffers`: forces the staged-and-reloaded object swap, so a later hook still reads the moved path. Red on the old fix, green on this one.

Local runs on Drupal 11: unit 33/33, kernel 88/88, lint clean with no new PHPStan findings. Also verified end to end in a browser with the Focal Point widget.

## What this does not fix

Retroactive update calls `filefield_paths_entity_update($entity)` directly in `Batch\Updater::batchProcess()` without re-saving the entity, so `focal_point_entity_update()` never fires and existing crops are orphaned at their old paths. Only Crop can fix that, by implementing `hook_file_move()`, which core already invokes from `FileRepository::move()`.

## Upstream state

Focal Point https://www.drupal.org/i/3042259 is still Needs Review. MR !61 was opened on 2026-08-01 from tvhung's 2019 patch and has not been touched since, and the newest Focal Point release predates it. The upstream fix has not shipped. The two changes are complementary: theirs reloads the file at the point of use, this one stops handing out a stale reference in the first place.

## Credit

- **Nuuou** reported it in 2018 with a full reproduction and the correct suspicion that File (Field) Paths was the culprit.
- **tvhung** diagnosed the URI change and wrote the original Focal Point patch in 2019.
- **nikitas** posted a working custom-module workaround in 2023.
- **justcaldwell** confirmed the fix and opened Focal Point MR !61 on 2026-08-01.
