### PR TITLE
test(#3432653): cover the migration path that reported the crash

### DIFF
--- a/tests/src/Kernel/FileFieldPathsProcessFileLegacyTest.php
+++ b/tests/src/Kernel/FileFieldPathsProcessFileLegacyTest.php
@@ -240,4 +240,34 @@ class FileFieldPathsProcessFileLegacyTest extends KernelTestBase {
     $this->assertFileExists('public://move-fail/example.txt');
   }
 
+  /**
+   * An unregistered temporary scheme is skipped rather than fatal.
+   *
+   * The old procedural code resolved the configured temp location with
+   * StreamWrapperManager::getViaUri() and called getType() on the result.
+   * That returns FALSE for a scheme no wrapper handles, which is why
+   * migrations died with "Call to a member function getType() on bool".
+   *
+   * @see https://www.drupal.org/i/3432653
+   */
+  public function testUnregisteredTemporarySchemeIsSkipped(): void {
+    $this->config('filefield_paths.settings')
+      ->set('temp_location', 'bogus://filefield_paths')
+      ->save();
+
+    $file = $this->createFile('public://guard-source/example.txt');
+    $entity = EntityTest::create(['field_file' => [['target_id' => $file->id()]]]);
+    $field = $entity->get('field_file');
+    \assert($field instanceof FileFieldItemList);
+
+    $settings = [
+      'file_path' => ['value' => 'guard-dest', 'options' => ['transliterate' => FALSE]],
+      'file_name' => ['value' => '', 'options' => ['transliterate' => FALSE]],
+    ];
+
+    $this->getService()->fileFieldPathsProcessFile($entity, $field, $settings);
+
+    $this->assertFileExists('public://guard-dest/example.txt');
+  }
+
 }

--- a/tests/src/Kernel/MigrateMediaFileTest.php
+++ b/tests/src/Kernel/MigrateMediaFileTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\filefield_paths\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\file\Entity\File;
+use Drupal\migrate\MigrateExecutable;
+use Drupal\migrate\MigrateMessage;
+use Drupal\migrate\Plugin\MigrationInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests processing a file field on media entities created by a migration.
+ *
+ * @group filefield_paths
+ * @covers \Drupal\filefield_paths\Hook\FileFieldPathsProcessFileLegacy
+ */
+#[Group('filefield_paths')]
+#[RunTestsInSeparateProcesses]
+class MigrateMediaFileTest extends KernelTestBase {
+
+  use MediaTypeCreationTrait;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array<string>
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'file',
+    'image',
+    'media',
+    'migrate',
+    'filefield_paths',
+  ];
+
+  /**
+   * The name of the media type's source field.
+   */
+  private string $sourceField;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('media');
+    $this->installSchema('file', ['file_usage']);
+    $this->installConfig(['field', 'system', 'image', 'file', 'media', 'filefield_paths']);
+
+    $media_type = $this->createMediaType('file', ['id' => 'document']);
+    $this->sourceField = $media_type->getSource()->getConfiguration()['source_field'];
+
+    $options = ['slashes' => FALSE, 'pathauto' => FALSE, 'transliterate' => FALSE];
+    $field = FieldConfig::loadByName('media', 'document', $this->sourceField);
+    $field->setThirdPartySetting('filefield_paths', 'enabled', TRUE);
+    $field->setThirdPartySetting('filefield_paths', 'file_path', [
+      'value' => 'migrated',
+      'options' => $options,
+    ]);
+    $field->setThirdPartySetting('filefield_paths', 'file_name', [
+      'value' => '',
+      'options' => $options,
+    ]);
+    $field->setThirdPartySetting('filefield_paths', 'active_updating', TRUE);
+    $field->setThirdPartySetting('filefield_paths', 'redirect', FALSE);
+    $field->setThirdPartySetting('filefield_paths', 'retroactive_update', FALSE);
+    $field->save();
+  }
+
+  /**
+   * Runs a migration that creates one media entity referencing one file.
+   *
+   * @param int $fid
+   *   The file to reference.
+   *
+   * @return \Drupal\migrate\MigrateExecutable
+   *   The executable, already run.
+   */
+  private function runMigration(int $fid): MigrateExecutable {
+    $definition = [
+      'migration_tags' => ['filefield_paths test'],
+      'source' => [
+        'plugin' => 'embedded_data',
+        'data_rows' => [['key' => 1, 'name' => 'Migrated document', 'fid' => $fid]],
+        'ids' => ['key' => ['type' => 'integer']],
+      ],
+      'process' => [
+        'name' => 'name',
+        $this->sourceField . '/target_id' => 'fid',
+      ],
+      'destination' => [
+        'plugin' => 'entity:media',
+        'default_bundle' => 'document',
+      ],
+    ];
+    $migration = $this->container->get('plugin.manager.migration')
+      ->createStubMigration($definition);
+    $executable = new MigrateExecutable($migration, new MigrateMessage());
+    // Assert the import itself, or an unrelated migration failure surfaces
+    // only as a missing file and reads like a regression in this module.
+    $this->assertSame(
+      MigrationInterface::RESULT_COMPLETED,
+      $executable->import(),
+      'The migration ran to completion.'
+    );
+    return $executable;
+  }
+
+  /**
+   * A migrated media entity has its file processed, without a fatal.
+   *
+   * The reported crash happened here: migrate saves the media entity, the
+   * process hook runs, and the old code resolved stream wrappers in a way
+   * that died when one could not be found.
+   *
+   * @see https://www.drupal.org/i/3432653
+   */
+  public function testMigratedMediaFileIsProcessed(): void {
+    $file_system = $this->container->get('file_system');
+    $directory = 'public://migrate-source';
+    $file_system->prepareDirectory($directory, $file_system::CREATE_DIRECTORY);
+    file_put_contents("$directory/example.txt", 'contents');
+    $file = File::create(['uri' => 'public://migrate-source/example.txt']);
+    $file->setPermanent();
+    $file->save();
+
+    $this->runMigration((int) $file->id());
+
+    $media = $this->container->get('entity_type.manager')
+      ->getStorage('media')
+      ->load(1);
+    $this->assertNotNull($media, 'The migration created the media entity.');
+    $this->assertFileExists('public://migrated/example.txt');
+  }
+
+  /**
+   * The same migration survives a temporary location with no stream wrapper.
+   *
+   * This is the reporter's environment: the configured temp location had no
+   * registered wrapper, and the old code called a method on the FALSE that
+   * StreamWrapperManager::getViaUri() returned for it. The current code never
+   * resolves the temp location on this path at all, which is why it survives,
+   * so this test guards the whole scenario rather than one branch.
+   *
+   * @see https://www.drupal.org/i/3432653
+   */
+  public function testMigrationSurvivesAnUnregisteredTemporaryScheme(): void {
+    $this->config('filefield_paths.settings')
+      ->set('temp_location', 'bogus://filefield_paths')
+      ->save();
+
+    // The scenario only reproduces the crash while this scheme really has no
+    // wrapper. getViaUri() returns FALSE here, and the old code called
+    // getType() straight on that.
+    $this->assertFalse(
+      $this->container->get('stream_wrapper_manager')->getViaUri('bogus://filefield_paths'),
+      'The configured temporary location must have no stream wrapper.'
+    );
+
+    $file_system = $this->container->get('file_system');
+    $directory = 'public://migrate-source';
+    $file_system->prepareDirectory($directory, $file_system::CREATE_DIRECTORY);
+    file_put_contents("$directory/example.txt", 'contents');
+    $file = File::create(['uri' => 'public://migrate-source/example.txt']);
+    $file->setPermanent();
+    $file->save();
+
+    $this->runMigration((int) $file->id());
+
+    $this->assertFileExists('public://migrated/example.txt');
+  }
+
+}


### PR DESCRIPTION
Refs https://www.drupal.org/project/filefield_paths/issues/3432653

## Summary

Test-only. The reported fatal is already fixed by the object oriented conversion; this adds the regression coverage that was never written.

## Why there is no fix here

The crash was `Call to a member function getType() on bool` at `filefield_paths.inc:75`. The old code resolved stream wrappers with `StreamWrapperManager::getViaUri(...)->getType()`, and `getViaUri()` returns FALSE for a scheme no wrapper handles. That file is now a deprecation stub that nothing loads, and the replacement never calls a method on a wrapper lookup: it parses the scheme and guards with `empty()` before use.

## Verification

Both reporters hit this during a migration, so the coverage goes in at that layer rather than by calling the service directly:

- `MigrateMediaFileTest` runs a real `MigrateExecutable` over an `embedded_data` source into `entity:media`, so the hook fires from `hook_entity_insert` inside a migration, and asserts the import returns `RESULT_COMPLETED`.
- The second case sets `temp_location` to an unregistered scheme, which is the reporter's environment, and asserts up front that the scheme really has no wrapper so the test cannot pass vacuously.
- `FileFieldPathsProcessFileLegacyTest::testUnregisteredTemporarySchemeIsSkipped` covers the same input at service level.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when processing files during media migrations.
  - File processing now safely handles unregistered temporary storage schemes without causing fatal errors.
  - Migrated media files are successfully processed and moved to their configured destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->