### PR TITLE
chore: stop renovate auto-merging, and clear the rector finding

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "extends": ["config:recommended"],
-    "automerge": true,
+    "automerge": false,
     "rangeStrategy": "bump",
     "dependencyDashboard": true,
     "pinDigests": true,

--- a/src/Drush/Commands/Commands.php
+++ b/src/Drush/Commands/Commands.php
@@ -145,11 +145,9 @@ final class Commands extends DrushCommands {
             ];
           }
 
-          if (!isset($info[$entity_type_name][$bundle])) {
-            $info[$entity_type_name][$bundle] = [
-              '#label' => sprintf('%s (%s)', $bundles_info[$bundle]['label'], $bundle),
-            ];
-          }
+          $info[$entity_type_name][$bundle] ??= [
+            '#label' => sprintf('%s (%s)', $bundles_info[$bundle]['label'], $bundle),
+          ];
           $field_instance = $this->entityFieldManager->getFieldDefinitions($entity_type_name, $bundle)[$field->getName()] ?? NULL;
           if ($field_instance && is_array($info[$entity_type_name][$bundle])) {
             $info[$entity_type_name][$bundle][$field_instance->getName()] = sprintf('%s (%s)', $field_instance->getLabel(), $field_instance->getName());


### PR DESCRIPTION
## Summary

Two pieces of CI hygiene. Neither changes module behaviour.

## Renovate stops merging its own pull requests

`renovate.json` carried `"automerge": true`, so dependency updates landed on `8.x-1.x` without anyone looking at them. Two did exactly that today, `#21` and `#22`, and each one pushed the GitHub mirror ahead of Drupal.org, which is where the module is actually canonical. The mirrors then have to be reconciled by hand, and a force-push is the only way to do it.

Set to `false`. Renovate still raises the pull requests and still keeps the dependency dashboard; they now wait for a human.

## Rector finding on the drush commands

`src/Drush/Commands/Commands.php:145` fails `rector --dry-run` with `IfToNullCoalescingAssignRector`. The code is unchanged since `5be2c0d8`; what changed is the rector version, which now flags a pattern it previously accepted.

This matters more than the finding itself: `lint` runs on pull requests but not on `8.x-1.x` (the only workflow there is `Deploy`, and it is skipped without its secrets). So the failure was invisible on the branch that owns it, and instead appeared as a red `lint` on every pull request opened against it, including four that never touch the file.

Applied rector's own suggested rewrite.

## Verification

`make lint` is clean, rector included, and the kernel suite is unchanged.
